### PR TITLE
Add manifest web export pipeline

### DIFF
--- a/docs/manifest/README.md
+++ b/docs/manifest/README.md
@@ -5,5 +5,6 @@
 - **combos.yml** — Curated bundles of rolls that “just work.”
 - **platters.yml** — Full environments that compose combos (and sometimes extra rolls).
 - **badges.yml** — UI labels/tooltips; SVGs live in `assets/badges/`.
+- **web/** — Machine-consumable JSON exports for websites and other clients.
 
-Consumers (site/homepage/CLI) can parse these files or rely on a CI step that emits a merged `menu.json`.
+Consumers (site/homepage/CLI) can parse these files or rely on the export helper `scripts/export-manifest-json.py`, which mirrors every YAML manifest into JSON under `docs/manifest/web/api/` and publishes an index file for cache-friendly retrieval.

--- a/docs/manifest/web/README.md
+++ b/docs/manifest/web/README.md
@@ -1,0 +1,40 @@
+# Web Data Exports
+
+This directory hosts machine-consumable exports of the manifest system for the Sushi Kitchen website and any other UI surfaces.  The source manifests under `docs/manifest/` remain the single source of truth.  A helper script converts the YAML bundles and templates into JSON that can be fetched directly by front-end code.
+
+## Folder layout
+
+```
+web/
+├── README.md               # This guide
+├── api/                    # JSON mirrors of the manifest YAML
+│   └── ...
+└── manifest-index.json     # Catalog of generated files with hashes and metadata
+```
+
+* `api/` mirrors the structure of the manifest tree.  For example, `core/combos.yml` becomes `web/api/core/combos.json`.
+* `manifest-index.json` lists every exported file, the manifest revision it was derived from, and a SHA-256 digest for cache validation.
+
+## Generating the exports
+
+Use the `scripts/export-manifest-json.py` helper to regenerate the JSON snapshot whenever any YAML manifest changes:
+
+```bash
+python scripts/export-manifest-json.py \
+  --manifest-root docs/manifest \
+  --output-dir docs/manifest/web/api
+```
+
+The script writes the converted JSON files and refreshes `manifest-index.json`.  By default it skips the archived manifests; add `--include-archives` if you need historical data.
+
+## Using the data in a website
+
+1. **Fetch the index** – Load `docs/manifest/web/manifest-index.json` to discover the available resources and the manifest metadata.
+2. **Pull only what you need** – Each entry provides a relative path to the JSON export.  Front ends can request the individual files they require (for example, `web/api/core/bento_box.json`).
+3. **Validate freshness** – Compare the stored SHA-256 digest against the file contents or watch the `generated_at` timestamp to trigger client-side cache invalidation.
+4. **Automate regeneration** – Wire the export script into CI so that new JSON snapshots land alongside every manifest change, keeping the website in sync with the source repository.
+
+## Extending the pipeline
+
+The exporter is schema-agnostic: any `.yml` or `.yaml` file under the manifest root is mirrored into JSON.  If additional normalization is required (for example, flattening Markdown tables or computing dependency graphs), add a post-processing step or extend the script with custom handlers per directory.
+

--- a/docs/manifest/web/api/core/badges.json
+++ b/docs/manifest/web/api/core/badges.json
@@ -1,0 +1,453 @@
+{
+  "schema_version": "0.1.0",
+  "icon_base_path": "assets/badges/",
+  "fallback_icon": "default.svg",
+  "categories": {
+    "adoption": {
+      "name": "Community Adoption",
+      "description": "Indicates community usage patterns and maturity",
+      "color_family": "green"
+    },
+    "requirements": {
+      "name": "Hardware Requirements",
+      "description": "Hardware dependencies and performance characteristics",
+      "color_family": "orange"
+    },
+    "deployment": {
+      "name": "Deployment Characteristics",
+      "description": "Deployment complexity and target environments",
+      "color_family": "blue"
+    },
+    "lifecycle": {
+      "name": "Development Lifecycle",
+      "description": "Development stage and stability indicators",
+      "color_family": "yellow"
+    },
+    "domain": {
+      "name": "Domain Specialization",
+      "description": "Specialized use cases and domain focus",
+      "color_family": "purple"
+    }
+  },
+  "badges": {
+    "popular": {
+      "label": "Popular",
+      "category": "adoption",
+      "color": "#28A745",
+      "background_color": "#D4EDDA",
+      "text_color": "#155724",
+      "icon": "star.svg",
+      "tooltip": "High community adoption with active maintenance and extensive documentation",
+      "weight": 100,
+      "usage_notes": "Services with proven track record and large user base"
+    },
+    "battle-tested": {
+      "label": "Battle Tested",
+      "category": "adoption",
+      "color": "#0056B3",
+      "background_color": "#D1ECF1",
+      "text_color": "#0C5460",
+      "icon": "shield-check.svg",
+      "tooltip": "Production-proven across multiple enterprise deployments",
+      "weight": 95,
+      "usage_notes": "Enterprise-grade reliability and stability"
+    },
+    "gpu": {
+      "label": "GPU Required",
+      "category": "requirements",
+      "color": "#FF6B35",
+      "background_color": "#FFE6E0",
+      "text_color": "#B8360A",
+      "icon": "gpu.svg",
+      "tooltip": "Requires CUDA-capable GPU for optimal performance. CPU fallback may be very slow",
+      "weight": 90,
+      "usage_notes": "Ensure NVIDIA GPU with sufficient VRAM before deployment",
+      "min_vram_gb": 8
+    },
+    "gpu-optional": {
+      "label": "GPU Optional",
+      "category": "requirements",
+      "color": "#FFA500",
+      "background_color": "#FFF3CD",
+      "text_color": "#856404",
+      "icon": "gpu-optional.svg",
+      "tooltip": "Runs on CPU but significantly faster with GPU acceleration",
+      "weight": 70,
+      "usage_notes": "CPU works but GPU provides 10-100x speedup",
+      "recommended_vram_gb": 4
+    },
+    "heavy": {
+      "label": "Heavy",
+      "category": "requirements",
+      "color": "#DC3545",
+      "background_color": "#F8D7DA",
+      "text_color": "#721C24",
+      "icon": "weight.svg",
+      "tooltip": "High resource requirements - ensure adequate RAM, storage, and CPU",
+      "weight": 85,
+      "usage_notes": "Monitor system resources carefully during deployment",
+      "min_ram_gb": 8,
+      "min_storage_gb": 50
+    },
+    "lightweight": {
+      "label": "Lightweight",
+      "category": "requirements",
+      "color": "#20C997",
+      "background_color": "#D1F2EB",
+      "text_color": "#0E6B47",
+      "icon": "feather.svg",
+      "tooltip": "Minimal resource requirements - works well on small machines",
+      "weight": 30,
+      "usage_notes": "Good for resource-constrained environments",
+      "max_ram_gb": 2
+    },
+    "enterprise": {
+      "label": "Enterprise",
+      "category": "deployment",
+      "color": "#17A2B8",
+      "background_color": "#D1ECF1",
+      "text_color": "#0C5460",
+      "icon": "building.svg",
+      "tooltip": "Designed for enterprise deployments with advanced configuration options",
+      "weight": 80,
+      "usage_notes": "Complex setup but powerful features for large organizations"
+    },
+    "k8s": {
+      "label": "Kubernetes",
+      "category": "deployment",
+      "color": "#326CE5",
+      "background_color": "#E7F1FF",
+      "text_color": "#1048A3",
+      "icon": "kubernetes.svg",
+      "tooltip": "Optimized for Kubernetes with advanced orchestration features",
+      "weight": 75,
+      "usage_notes": "Best deployed on Kubernetes clusters with Helm charts"
+    },
+    "edge": {
+      "label": "Edge Ready",
+      "category": "deployment",
+      "color": "#6610F2",
+      "background_color": "#E8D5FF",
+      "text_color": "#3D0A91",
+      "icon": "edge.svg",
+      "tooltip": "Optimized for edge computing and low-latency deployments",
+      "weight": 60,
+      "usage_notes": "Designed for distributed edge environments"
+    },
+    "cloud-native": {
+      "label": "Cloud Native",
+      "category": "deployment",
+      "color": "#0D6EFD",
+      "background_color": "#CCE5FF",
+      "text_color": "#0B4D37",
+      "icon": "cloud.svg",
+      "tooltip": "Designed with cloud-first principles and auto-scaling capabilities",
+      "weight": 65,
+      "usage_notes": "Best performance in cloud environments with auto-scaling"
+    },
+    "optional": {
+      "label": "Optional",
+      "category": "lifecycle",
+      "color": "#6C757D",
+      "background_color": "#F8F9FA",
+      "text_color": "#495057",
+      "icon": "circle-dashed.svg",
+      "tooltip": "Not required for most builds - enable for specific use cases",
+      "weight": 20,
+      "usage_notes": "Add when you need specific functionality this provides"
+    },
+    "experimental": {
+      "label": "Experimental",
+      "category": "lifecycle",
+      "color": "#FFC107",
+      "background_color": "#FFF8E1",
+      "text_color": "#533F03",
+      "icon": "beaker.svg",
+      "tooltip": "Early-stage technology - expect potential breaking changes",
+      "weight": 15,
+      "usage_notes": "Use with caution in production environments"
+    },
+    "deprecated": {
+      "label": "Deprecated",
+      "category": "lifecycle",
+      "color": "#6C757D",
+      "background_color": "#F1F3F4",
+      "text_color": "#495057",
+      "icon": "archive.svg",
+      "tooltip": "Being phased out - use alternatives for new deployments",
+      "weight": 5,
+      "usage_notes": "Migration path available in documentation"
+    },
+    "future": {
+      "label": "Roadmap",
+      "category": "lifecycle",
+      "color": "#868E96",
+      "background_color": "#E9ECEF",
+      "text_color": "#495057",
+      "icon": "calendar.svg",
+      "tooltip": "Planned for future versions - subject to change",
+      "weight": 10,
+      "usage_notes": "Not yet available - planned implementation"
+    },
+    "beta": {
+      "label": "Beta",
+      "category": "lifecycle",
+      "color": "#FD7E14",
+      "background_color": "#FFF0E6",
+      "text_color": "#7A3914",
+      "icon": "test-tube.svg",
+      "tooltip": "Beta quality - stable but may have minor issues",
+      "weight": 40,
+      "usage_notes": "Generally stable but test thoroughly before production"
+    },
+    "ci": {
+      "label": "CI/CD",
+      "category": "domain",
+      "color": "#20C997",
+      "background_color": "#D1F2EB",
+      "text_color": "#0E6B47",
+      "icon": "git-branch.svg",
+      "tooltip": "Primarily used in development and CI/CD workflows",
+      "weight": 50,
+      "usage_notes": "Essential for development and deployment pipelines"
+    },
+    "security": {
+      "label": "Security",
+      "category": "domain",
+      "color": "#E74C3C",
+      "background_color": "#FADBD8",
+      "text_color": "#A93226",
+      "icon": "lock.svg",
+      "tooltip": "Security-focused service with hardening and compliance features",
+      "weight": 85,
+      "usage_notes": "Critical for secure deployments and compliance"
+    },
+    "compliance": {
+      "label": "Compliance",
+      "category": "domain",
+      "color": "#8E44AD",
+      "background_color": "#EBDEF0",
+      "text_color": "#6A1B9A",
+      "icon": "check-circle.svg",
+      "tooltip": "Supports regulatory compliance requirements (GDPR, HIPAA, SOX)",
+      "weight": 80,
+      "usage_notes": "Required for regulated industries and data privacy"
+    },
+    "research": {
+      "label": "Research",
+      "category": "domain",
+      "color": "#3498DB",
+      "background_color": "#D6EAF8",
+      "text_color": "#1F618D",
+      "icon": "microscope.svg",
+      "tooltip": "Optimized for research workflows and academic use cases",
+      "weight": 55,
+      "usage_notes": "Excellent for research and experimentation"
+    },
+    "production": {
+      "label": "Production",
+      "category": "domain",
+      "color": "#27AE60",
+      "background_color": "#D5F4E6",
+      "text_color": "#186A3B",
+      "icon": "server.svg",
+      "tooltip": "Production-ready with monitoring, scaling, and reliability features",
+      "weight": 90,
+      "usage_notes": "Battle-tested for production workloads"
+    }
+  },
+  "combination_rules": {
+    "mutually_exclusive": [
+      [
+        "gpu",
+        "gpu-optional"
+      ],
+      [
+        "experimental",
+        "production",
+        "battle-tested"
+      ],
+      [
+        "deprecated",
+        "future"
+      ],
+      [
+        "lightweight",
+        "heavy"
+      ]
+    ],
+    "common_combinations": [
+      [
+        "popular",
+        "production"
+      ],
+      [
+        "gpu",
+        "heavy"
+      ],
+      [
+        "enterprise",
+        "battle-tested"
+      ],
+      [
+        "experimental",
+        "research"
+      ],
+      [
+        "security",
+        "compliance"
+      ],
+      [
+        "k8s",
+        "cloud-native"
+      ]
+    ],
+    "recommended_with": {
+      "gpu": [
+        "heavy"
+      ],
+      "enterprise": [
+        "security"
+      ],
+      "compliance": [
+        "security"
+      ],
+      "experimental": [
+        "optional"
+      ]
+    }
+  },
+  "display_config": {
+    "web": {
+      "max_badges_per_service": 4,
+      "show_tooltip_on_hover": true,
+      "badge_spacing": "4px",
+      "border_radius": "12px",
+      "font_size": "11px",
+      "font_weight": "500"
+    },
+    "cli": {
+      "use_emoji": true,
+      "show_full_label": false,
+      "color_support": true,
+      "emoji_mapping": {
+        "popular": "⭐",
+        "gpu": "🎮",
+        "gpu-optional": "🔧",
+        "heavy": "🏋️",
+        "enterprise": "🏢",
+        "experimental": "🧪",
+        "optional": "➡️",
+        "security": "🔒",
+        "production": "🚀"
+      }
+    },
+    "docs": {
+      "show_category": true,
+      "show_tooltip": true,
+      "markdown_format": "**{label}** - {tooltip}"
+    }
+  },
+  "validation": {
+    "max_badges_per_service": 5,
+    "required_for_types": {
+      "inference_engine": [
+        "gpu",
+        "gpu-optional"
+      ],
+      "security_service": [
+        "security"
+      ],
+      "monitoring_service": [
+        "production"
+      ]
+    },
+    "warn_combinations": [
+      {
+        "badges": [
+          "experimental",
+          "enterprise"
+        ],
+        "message": "Enterprise services should be stable - consider 'beta' instead"
+      },
+      {
+        "badges": [
+          "deprecated",
+          "popular"
+        ],
+        "message": "Popular services shouldn't be deprecated without migration path"
+      },
+      {
+        "badges": [
+          "lightweight",
+          "gpu"
+        ],
+        "message": "GPU services typically require significant resources"
+      }
+    ]
+  },
+  "i18n": {
+    "supported_languages": [
+      "en",
+      "es",
+      "fr",
+      "de",
+      "ja",
+      "zh"
+    ],
+    "translations": {
+      "popular": {
+        "en": {
+          "label": "Popular",
+          "tooltip": "High community adoption with active maintenance"
+        },
+        "es": {
+          "label": "Popular",
+          "tooltip": "Alta adopción comunitaria con mantenimiento activo"
+        },
+        "fr": {
+          "label": "Populaire",
+          "tooltip": "Forte adoption communautaire avec maintenance active"
+        },
+        "de": {
+          "label": "Beliebt",
+          "tooltip": "Hohe Community-Akzeptanz mit aktiver Wartung"
+        },
+        "ja": {
+          "label": "人気",
+          "tooltip": "活発なメンテナンスを伴うコミュニティでの高い採用"
+        },
+        "zh": {
+          "label": "热门",
+          "tooltip": "高社区采用率，维护活跃"
+        }
+      },
+      "gpu": {
+        "en": {
+          "label": "GPU Required",
+          "tooltip": "Requires CUDA-capable GPU for optimal performance"
+        },
+        "es": {
+          "label": "GPU Requerida",
+          "tooltip": "Requiere GPU compatible con CUDA para rendimiento óptimo"
+        },
+        "fr": {
+          "label": "GPU Requis",
+          "tooltip": "Nécessite un GPU compatible CUDA pour des performances optimales"
+        },
+        "de": {
+          "label": "GPU Erforderlich",
+          "tooltip": "Benötigt CUDA-fähige GPU für optimale Leistung"
+        },
+        "ja": {
+          "label": "GPU必須",
+          "tooltip": "最適なパフォーマンスにはCUDA対応GPUが必要"
+        },
+        "zh": {
+          "label": "需要GPU",
+          "tooltip": "需要支持CUDA的GPU以获得最佳性能"
+        }
+      }
+    }
+  }
+}

--- a/docs/manifest/web/api/core/bento-box.json
+++ b/docs/manifest/web/api/core/bento-box.json
@@ -1,0 +1,219 @@
+{
+  "schema_version": "0.1.0",
+  "bento_boxes": [
+    {
+      "id": "bento.ai-agent-foundation",
+      "name": "AI Agent Foundation",
+      "description": "A complete local AI infrastructure that provides everything needed to build and deploy intelligent agents without relying on cloud services. This bento box creates a self-contained ecosystem where Ollama serves local language models, n8n orchestrates complex multi-step workflows, Supabase provides a robust database foundation with built-in authentication and vector storage, Open WebUI offers an intuitive chat interface for interacting with your agents, and Caddy handles all the networking and SSL termination automatically. Together, these services solve the fundamental challenge of creating production-ready AI agents that can operate entirely within your own infrastructure while maintaining professional-grade reliability and security. The combination is specifically designed for teams and individuals who want to experiment with agent architectures without the complexity of enterprise-scale deployments.",
+      "includes": [
+        "hosomaki.ollama",
+        "hosomaki.n8n",
+        "futomaki.supabase",
+        "nigiri.open-webui",
+        "hosomaki.caddy"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.llm-api",
+        "cap.workflow",
+        "cap.database",
+        "cap.chat-ui",
+        "cap.reverse-proxy"
+      ],
+      "category": "agents",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 25,
+      "resource_estimate": {
+        "cpu_cores": 6,
+        "ram_gb": 12,
+        "vram_gb": 0
+      },
+      "warnings": [
+        "Supabase requires careful configuration of authentication and database settings",
+        "Plan your domain structure before deploying with Caddy"
+      ],
+      "success_criteria": [
+        "Chat with a local model through Open WebUI",
+        "Create and execute a simple n8n workflow",
+        "Store and retrieve data from Supabase",
+        "All services accessible through Caddy reverse proxy"
+      ],
+      "notes": "Perfect foundation for agent development; inspired by popular local AI stacks but optimized for clarity"
+    },
+    {
+      "id": "bento.knowledge-search-system",
+      "name": "Knowledge & Search System",
+      "description": "An advanced knowledge management platform that combines multiple AI technologies to create a comprehensive information discovery and analysis system. Qdrant provides lightning-fast vector similarity search for semantic document discovery, while Neo4j maps complex relationships between concepts and entities in your knowledge base. Flowise offers a visual interface for building sophisticated AI chains that can query, analyze, and synthesize information across these data stores. Langfuse monitors and optimizes your AI workflows with detailed analytics and performance tracking, and SearXNG aggregates web search results from multiple sources while maintaining privacy. This combination addresses the growing need for intelligent knowledge systems that can understand context, discover hidden connections, and provide comprehensive answers by combining internal knowledge with external research capabilities.",
+      "includes": [
+        "futomaki.qdrant",
+        "futomaki.neo4j",
+        "temaki.flowise",
+        "inari.langfuse",
+        "otsumami.searxng"
+      ],
+      "optional": [
+        "futomaki.infinity"
+      ],
+      "provides": [
+        "cap.vector-db",
+        "cap.graph-db",
+        "cap.agent-builder",
+        "cap.llm-observability",
+        "cap.web-search"
+      ],
+      "category": "knowledge",
+      "difficulty": "advanced",
+      "estimated_setup_time_min": 35,
+      "resource_estimate": {
+        "cpu_cores": 8,
+        "ram_gb": 16,
+        "vram_gb": 0
+      },
+      "warnings": [
+        "Neo4j requires sufficient memory allocation for large knowledge graphs",
+        "SearXNG needs proper configuration to avoid rate limiting from search engines"
+      ],
+      "success_criteria": [
+        "Upload documents and perform semantic search in Qdrant",
+        "Create knowledge relationships in Neo4j and query them",
+        "Build a multi-step research workflow in Flowise",
+        "Monitor AI operations and costs in Langfuse",
+        "Aggregate search results from multiple sources via SearXNG"
+      ],
+      "notes": "Advanced setup for research teams and knowledge workers; requires understanding of vector and graph concepts"
+    },
+    {
+      "id": "bento.content-creation-studio",
+      "name": "Content Creation Studio",
+      "description": "A complete multimedia content production environment designed for creators who need to process video, audio, and images at scale. FFmpeg handles all video and audio processing tasks from format conversion to complex filtering and editing operations, while Whisper provides accurate speech-to-text transcription for creating captions, searchable transcripts, and content analysis. Piper offers high-quality text-to-speech for generating narration and voiceovers in multiple languages and voices. n8n orchestrates automated workflows that can process batches of content, generate thumbnails, create social media variants, and manage publishing pipelines. MinIO provides scalable object storage for organizing raw footage, processed outputs, and media assets with S3-compatible APIs that integrate with external services. This bento box solves the complex challenge of managing large-scale content production workflows while maintaining quality and efficiency throughout the creative process.",
+      "includes": [
+        "uramaki.ffmpeg",
+        "nigiri.whisper",
+        "nigiri.piper",
+        "hosomaki.n8n",
+        "futomaki.minio"
+      ],
+      "optional": [
+        "uramaki.comfyui"
+      ],
+      "provides": [
+        "cap.media-tool",
+        "cap.asr",
+        "cap.tts",
+        "cap.workflow",
+        "cap.object-store"
+      ],
+      "category": "creative",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 20,
+      "resource_estimate": {
+        "cpu_cores": 6,
+        "ram_gb": 12,
+        "vram_gb": 4
+      },
+      "warnings": [
+        "Video processing can consume significant CPU and storage resources",
+        "ComfyUI models can exceed 10GB and require GPU for optimal performance",
+        "Whisper larger models improve accuracy but increase processing time significantly"
+      ],
+      "success_criteria": [
+        "Convert video files between formats using FFmpeg",
+        "Generate accurate transcripts from video audio using Whisper",
+        "Create voice narration from text using Piper",
+        "Set up automated content processing workflows in n8n",
+        "Store and organize media assets in MinIO buckets"
+      ],
+      "notes": "Designed for content creators with external storage; assumes cloud or external drive for video files"
+    },
+    {
+      "id": "bento.content-intelligence",
+      "name": "Content Intelligence",
+      "description": "A sophisticated content analysis and organization platform that transforms unstructured media libraries into searchable, queryable knowledge systems. Whisper transcribes thousands of videos into accurate text representations, creating a foundation for content understanding and searchability. Supabase stores both the structured metadata and vector embeddings of transcripts, enabling complex queries across your entire content library. Qdrant provides semantic search capabilities that can find videos based on topics, themes, or concepts even when specific keywords aren't mentioned. Neo4j maps relationships between content pieces, identifying recurring themes, guest appearances, and topic evolution over time. AnythingLLM creates an interactive interface where you can ask natural language questions about your content archive and receive comprehensive answers that draw from across your entire library. This system addresses the critical challenge faced by prolific content creators who have valuable insights buried in thousands of hours of video but lack efficient ways to discover, analyze, and repurpose that intellectual capital.",
+      "includes": [
+        "nigiri.whisper",
+        "futomaki.supabase",
+        "futomaki.qdrant",
+        "futomaki.neo4j",
+        "hosomaki.anythingllm",
+        "hosomaki.n8n"
+      ],
+      "optional": [
+        "futomaki.infinity"
+      ],
+      "provides": [
+        "cap.asr",
+        "cap.database",
+        "cap.vector-db",
+        "cap.graph-db",
+        "cap.rag-ui",
+        "cap.workflow"
+      ],
+      "category": "intelligence",
+      "difficulty": "advanced",
+      "estimated_setup_time_min": 40,
+      "resource_estimate": {
+        "cpu_cores": 8,
+        "ram_gb": 20,
+        "vram_gb": 6
+      },
+      "warnings": [
+        "Processing large video libraries requires substantial storage and processing time",
+        "Vector embeddings for thousands of documents need significant RAM allocation",
+        "Initial content ingestion pipeline may take days for large archives"
+      ],
+      "success_criteria": [
+        "Successfully transcribe multiple video formats and languages",
+        "Query content semantically and find relevant videos by topic",
+        "Visualize content relationships and theme evolution in Neo4j",
+        "Ask complex questions about your content library through AnythingLLM",
+        "Automate content ingestion and analysis workflows"
+      ],
+      "notes": "Designed for creators with extensive video archives; requires external storage for video files"
+    },
+    {
+      "id": "bento.content-repurposing-engine",
+      "name": "Content Repurposing Engine",
+      "description": "An automated content transformation platform that takes existing video content and intelligently repurposes it into multiple formats optimized for different platforms and audiences. FFmpeg handles all video processing operations including format conversion, aspect ratio adjustments for different social platforms, clip extraction, and quality optimization. ImageMagick processes thumbnails, social media graphics, and visual assets with automated resizing and format conversion for platform-specific requirements. n8n orchestrates sophisticated workflows that can analyze video content, identify key moments for clip creation, generate multiple aspect ratio versions (16:9 for YouTube, 9:16 for TikTok, 1:1 for Instagram), and create complete publishing packages. MinIO manages the storage and organization of all generated assets with automated cleanup and archiving policies. rclone provides seamless integration with cloud storage services and social media platforms for automated distribution. This bento box solves the time-consuming challenge of manually adapting content for multiple platforms, enabling creators to maintain consistent presence across all social channels while maximizing the value of their original content investments.",
+      "includes": [
+        "uramaki.ffmpeg",
+        "uramaki.imagemagick",
+        "hosomaki.n8n",
+        "futomaki.minio",
+        "uramaki.rclone",
+        "nigiri.whisper"
+      ],
+      "optional": [
+        "uramaki.comfyui"
+      ],
+      "provides": [
+        "cap.media-tool",
+        "cap.image-tool",
+        "cap.workflow",
+        "cap.object-store",
+        "cap.sync-tool",
+        "cap.asr"
+      ],
+      "category": "repurposing",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 30,
+      "resource_estimate": {
+        "cpu_cores": 6,
+        "ram_gb": 16,
+        "vram_gb": 4
+      },
+      "warnings": [
+        "Batch processing operations can consume significant computational resources",
+        "Multiple format generation multiplies storage requirements substantially",
+        "Cloud sync operations may incur bandwidth costs with large video files"
+      ],
+      "success_criteria": [
+        "Generate multiple aspect ratio versions of source videos automatically",
+        "Create platform-specific thumbnails and graphics from video frames",
+        "Set up automated workflows for content adaptation and distribution",
+        "Sync processed content to cloud storage and social platforms",
+        "Extract searchable transcripts for content analysis and SEO"
+      ],
+      "notes": "Optimized for high-volume content adaptation; requires planning for storage and bandwidth usage"
+    }
+  ]
+}

--- a/docs/manifest/web/api/core/combos.json
+++ b/docs/manifest/web/api/core/combos.json
@@ -1,0 +1,308 @@
+{
+  "schema_version": "0.1.0",
+  "combos": [
+    {
+      "id": "combo.chat-local",
+      "name": "Local Chat",
+      "description": "The simplest possible setup for chatting with local AI models. This combo pairs Ollama's local LLM inference with Open WebUI's clean chat interface, creating a completely private ChatGPT-like experience that runs entirely on your machine. Ollama handles downloading and running models like Llama or Mistral, while Open WebUI provides the familiar conversational interface you're used to from cloud AI services. Perfect for getting started with local AI without any complexity - just download a model and start chatting.",
+      "includes": [
+        "hosomaki.ollama",
+        "nigiri.open-webui"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.llm-api",
+        "cap.chat-ui"
+      ],
+      "category": "chat",
+      "difficulty": "easy",
+      "estimated_setup_time_min": 5,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 4,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Open WebUI loads and connects to Ollama successfully",
+        "Download a model (like llama3.1) and have a conversation"
+      ],
+      "notes": "Ideal first combo for AI newcomers; add more services later as needs grow"
+    },
+    {
+      "id": "combo.dev-workspace",
+      "name": "Dev Workspace",
+      "description": "A complete development environment that runs in your browser, designed for AI and data science projects. VS Code Server provides a full IDE experience accessible from any device, while JupyterLab offers interactive notebooks perfect for data exploration and ML experimentation. Docusaurus rounds out the workspace by providing a modern documentation site generator that integrates beautifully with your code repositories. This combination solves the challenge of maintaining consistent development environments across different machines and team members, while providing the specialized tools needed for AI development workflows.",
+      "includes": [
+        "temaki.vscode-server",
+        "chirashi.jupyterlab",
+        "sashimi.docusaurus"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.dev-env",
+        "cap.notebooks",
+        "cap.docs-site"
+      ],
+      "category": "dev",
+      "difficulty": "easy",
+      "estimated_setup_time_min": 8,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 4,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Open VS Code Server in the browser and connect",
+        "Launch JupyterLab and run a Python cell",
+        "Serve docs locally and view the homepage"
+      ],
+      "notes": "Great first combo for developers; pairs well with monitoring and storage combos"
+    },
+    {
+      "id": "combo.knowledge-rag",
+      "name": "Knowledge RAG",
+      "description": "A turnkey solution for building retrieval-augmented generation (RAG) systems that can chat with your documents. AnythingLLM provides an intuitive interface for uploading documents and asking questions, while Qdrant serves as the high-performance vector database that stores document embeddings for semantic search. LiteLLM acts as a universal gateway that can connect to both local models (via Ollama) and cloud APIs, giving you flexibility in model selection. This combo solves the fundamental challenge of making your private documents queryable through natural language, enabling you to build knowledge bases that can answer complex questions by understanding context and relationships across your entire document collection.",
+      "includes": [
+        "hosomaki.anythingllm",
+        "futomaki.qdrant",
+        "hosomaki.litellm"
+      ],
+      "optional": [
+        "futomaki.infinity"
+      ],
+      "provides": [
+        "cap.rag-ui",
+        "cap.vector-db",
+        "cap.llm-api"
+      ],
+      "category": "rag",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 12,
+      "resource_estimate": {
+        "cpu_cores": 4,
+        "ram_gb": 8,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Upload a document and get a grounded answer from AnythingLLM",
+        "Vector search returns relevant chunks for queries",
+        "Latency under 2 seconds for simple questions"
+      ],
+      "notes": "Add Infinity for faster embeddings; works with both local and cloud LLMs"
+    },
+    {
+      "id": "combo.flow-builder",
+      "name": "Flow Builder",
+      "description": "A visual, no-code platform for building AI agents and complex workflows without writing any code. Flowise provides an intuitive drag-and-drop interface for creating AI chains, while LiteLLM ensures you can connect to any language model seamlessly. This combo addresses the growing need for non-technical users to build sophisticated AI workflows, from simple chatbots to complex multi-step agents that can call APIs, process documents, and make decisions. The visual approach makes it easy to understand and debug AI workflows, while the underlying systems handle the complex orchestration and model management automatically.",
+      "includes": [
+        "temaki.flowise",
+        "hosomaki.litellm"
+      ],
+      "optional": [
+        "temaki.dify"
+      ],
+      "provides": [
+        "cap.agent-builder",
+        "cap.llm-api"
+      ],
+      "category": "agents",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 10,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 4,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Create a simple chain/flow in Flowise and execute it end-to-end",
+        "Connect to an LLM through LiteLLM successfully"
+      ],
+      "notes": "Dify offers alternative flow-building approach; choose one that fits your style"
+    },
+    {
+      "id": "combo.monitor-basic",
+      "name": "Basic Monitoring",
+      "description": "Essential monitoring infrastructure that provides insight into your AI stack's performance and health. Prometheus collects detailed metrics from all your services, Grafana transforms that data into beautiful, actionable dashboards, and cAdvisor specifically monitors Docker container resource usage. This combination solves the critical problem of understanding what's happening inside your AI systems - which services are consuming resources, how fast your models are responding, and whether everything is running smoothly. The setup provides the foundation for identifying bottlenecks, planning capacity, and troubleshooting issues before they become problems.",
+      "includes": [
+        "inari.prometheus",
+        "inari.grafana",
+        "inari.cadvisor"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.metrics",
+        "cap.dashboards",
+        "cap.container-metrics"
+      ],
+      "category": "observability",
+      "difficulty": "easy",
+      "estimated_setup_time_min": 7,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 2,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Grafana shows Prometheus datasource connected",
+        "Container metrics visible in dashboards",
+        "Service health status indicators working"
+      ],
+      "notes": "Essential for any serious deployment; upgrade to advanced monitoring for production"
+    },
+    {
+      "id": "combo.security-core",
+      "name": "Security Core",
+      "description": "Fundamental security infrastructure that protects your AI services with enterprise-grade authentication and secrets management. Authentik provides single sign-on (SSO) capabilities, allowing users to access multiple services with one secure login, while Infisical manages application secrets, API keys, and configuration safely. Vaultwarden rounds out the setup by providing a self-hosted password manager for your team. This combo addresses the critical security challenges of AI deployments: ensuring only authorized users can access sensitive AI models and data, protecting API keys and configuration from exposure, and maintaining security best practices as your stack grows in complexity.",
+      "includes": [
+        "gunkanmaki.authentik",
+        "gunkanmaki.infisical",
+        "gunkanmaki.vaultwarden"
+      ],
+      "optional": [
+        "gunkanmaki.keycloak"
+      ],
+      "provides": [
+        "cap.sso",
+        "cap.secrets",
+        "cap.passwords"
+      ],
+      "category": "security",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 18,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 4,
+        "vram_gb": 0
+      },
+      "warnings": [
+        "Plan your domain/issuer URLs before enabling SSO in applications"
+      ],
+      "success_criteria": [
+        "Login via Authentik and access protected services",
+        "Store and retrieve a secret from Infisical",
+        "Import passwords into Vaultwarden successfully"
+      ],
+      "notes": "Keycloak offers more features but requires more configuration; start with Authentik"
+    },
+    {
+      "id": "combo.storage-essentials",
+      "name": "Storage Essentials",
+      "description": "Core data storage and management infrastructure that provides both object storage and database administration capabilities. MinIO creates an S3-compatible object store perfect for storing AI models, datasets, and generated content, while pgAdmin offers a powerful web interface for managing PostgreSQL databases. This combo solves the fundamental data management needs of AI applications: securely storing large files like models and datasets, organizing and backing up structured data, and providing easy access to database administration without requiring command-line expertise. The combination ensures you have both the bulk storage needed for AI assets and the database tooling required for application data.",
+      "includes": [
+        "futomaki.minio",
+        "futomaki.pgadmin"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.object-storage",
+        "cap.db-admin"
+      ],
+      "category": "data",
+      "difficulty": "easy",
+      "estimated_setup_time_min": 6,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 2,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Create a bucket in MinIO and upload a test file",
+        "Connect pgAdmin to a PostgreSQL database successfully"
+      ],
+      "notes": "Perfect complement to RAG and development combos; scales well with usage"
+    },
+    {
+      "id": "combo.inference-fast",
+      "name": "Fast Inference",
+      "description": "Optimized AI model serving designed for production workloads that demand speed and efficiency. vLLM provides state-of-the-art inference optimization with features like continuous batching and PagedAttention, dramatically improving throughput for language models. This combo addresses the performance gap between development and production AI serving - while Ollama is perfect for experimentation, vLLM is engineered for scenarios where you need to serve many concurrent users with minimal latency. The setup includes OpenAI-compatible APIs, making it easy to switch existing applications from development to production serving without code changes.",
+      "includes": [
+        "hosomaki.vllm"
+      ],
+      "optional": [
+        "hosomaki.tgi"
+      ],
+      "provides": [
+        "cap.llm-api",
+        "cap.gpu-infer"
+      ],
+      "category": "inference",
+      "difficulty": "advanced",
+      "estimated_setup_time_min": 12,
+      "resource_estimate": {
+        "cpu_cores": 8,
+        "ram_gb": 16,
+        "vram_gb": 16
+      },
+      "warnings": [
+        "Requires recent NVIDIA drivers and working CUDA runtime",
+        "Ensure model storage has sufficient space and fast I/O"
+      ],
+      "success_criteria": [
+        "Serve a model and respond to OpenAI-format requests under 200ms per token",
+        "Handle multiple concurrent requests without degradation"
+      ],
+      "notes": "TGI offers alternative optimization approach; both provide significant speedup over basic serving"
+    },
+    {
+      "id": "combo.media-basic",
+      "name": "Media Toolkit",
+      "description": "Essential media processing capabilities for handling images, videos, and audio in AI workflows. FFmpeg serves as the Swiss Army knife for media conversion, supporting virtually every audio and video format while providing powerful filtering and transformation capabilities. ImageMagick complements this with comprehensive image processing, from simple resizing to complex manipulations and format conversions. This combo solves the common problem of preparing media assets for AI processing - converting videos to the right format for transcription, resizing images for model input, extracting audio tracks, and generating thumbnails. Together, these tools form the foundation for any AI application that works with multimedia content.",
+      "includes": [
+        "uramaki.ffmpeg",
+        "uramaki.imagemagick"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.media-processing"
+      ],
+      "category": "media",
+      "difficulty": "easy",
+      "estimated_setup_time_min": 4,
+      "resource_estimate": {
+        "cpu_cores": 2,
+        "ram_gb": 2,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Convert a video file to different format successfully",
+        "Resize and convert images using ImageMagick"
+      ],
+      "notes": "Lightweight but powerful; essential for any media-focused AI workflows"
+    },
+    {
+      "id": "combo.analytics-starter",
+      "name": "Analytics Starter",
+      "description": "A complete platform for data analysis and machine learning experimentation that combines interactive computing with experiment tracking. JupyterLab provides the familiar notebook environment for data exploration, model development, and visualization, while MLflow tracks experiments, manages model versions, and facilitates collaboration between data scientists. This combo addresses the challenge of maintaining reproducible data science workflows - ensuring that experiments can be recreated, models can be properly versioned, and insights can be shared across teams. The combination provides both the interactive development environment needed for exploration and the systematic tracking required for production ML workflows.",
+      "includes": [
+        "chirashi.jupyterlab",
+        "chirashi.mlflow"
+      ],
+      "optional": [],
+      "provides": [
+        "cap.notebooks",
+        "cap.experiment-tracking"
+      ],
+      "category": "analytics",
+      "difficulty": "intermediate",
+      "estimated_setup_time_min": 8,
+      "resource_estimate": {
+        "cpu_cores": 3,
+        "ram_gb": 6,
+        "vram_gb": 0
+      },
+      "warnings": [],
+      "success_criteria": [
+        "Run a notebook and track an experiment in MLflow",
+        "View experiment results and model artifacts in MLflow UI"
+      ],
+      "notes": "Perfect for data science teams; integrates well with storage and monitoring combos"
+    }
+  ]
+}

--- a/docs/manifest/web/api/core/contracts.json
+++ b/docs/manifest/web/api/core/contracts.json
@@ -1,0 +1,4408 @@
+{
+  "schema_version": "0.1.0",
+  "last_updated": "2025-09-17",
+  "capabilities": {
+    "cap.vector-db": {
+      "description": "Vector database for embeddings and similarity search",
+      "providers": [
+        "futomaki.qdrant",
+        "futomaki.weaviate",
+        "futomaki.chroma"
+      ],
+      "interface": "REST API with vector operations"
+    },
+    "cap.graph-db": {
+      "description": "Graph database for relationship and network data",
+      "providers": [
+        "futomaki.neo4j"
+      ],
+      "interface": "Cypher/GraphQL query interface"
+    },
+    "cap.database": {
+      "description": "SQL database for structured data",
+      "providers": [
+        "futomaki.postgres",
+        "futomaki.supabase"
+      ],
+      "interface": "SQL query interface"
+    },
+    "cap.object-storage": {
+      "description": "S3-compatible object storage for files and artifacts",
+      "providers": [
+        "futomaki.minio"
+      ],
+      "interface": "S3 API compatibility"
+    },
+    "cap.redis": {
+      "description": "In-memory caching and session storage",
+      "providers": [
+        "futomaki.redis"
+      ],
+      "interface": "Redis protocol"
+    },
+    "cap.backup": {
+      "description": "Encrypted backup and restore capabilities",
+      "providers": [
+        "futomaki.restic"
+      ],
+      "interface": "CLI and API backup operations"
+    },
+    "cap.analytics-db": {
+      "description": "Fast analytics and OLAP database",
+      "providers": [
+        "otsumami.duckdb",
+        "otsumami.sqlite"
+      ],
+      "interface": "SQL interface optimized for analytics"
+    },
+    "cap.llm-api": {
+      "description": "Local large language model inference",
+      "providers": [
+        "hosomaki.ollama",
+        "hosomaki.vllm"
+      ],
+      "interface": "OpenAI-compatible API"
+    },
+    "cap.llm-gateway": {
+      "description": "Gateway to cloud LLM providers",
+      "providers": [
+        "hosomaki.litellm"
+      ],
+      "interface": "Unified LLM API"
+    },
+    "cap.embeddings": {
+      "description": "Text to vector embedding conversion",
+      "providers": [
+        "hosomaki.ollama",
+        "futomaki.infinity"
+      ],
+      "interface": "Embedding API"
+    },
+    "cap.gpu-infer": {
+      "description": "High-performance GPU-accelerated inference",
+      "providers": [
+        "hosomaki.vllm",
+        "hosomaki.tgi",
+        "hosomaki.triton"
+      ],
+      "interface": "Optimized inference API"
+    },
+    "cap.asr": {
+      "description": "Automatic speech recognition and transcription",
+      "providers": [
+        "nigiri.whisper"
+      ],
+      "interface": "Audio file to text API"
+    },
+    "cap.tts": {
+      "description": "Text to speech synthesis",
+      "providers": [
+        "nigiri.piper",
+        "nigiri.openvoice"
+      ],
+      "interface": "Text to audio file API"
+    },
+    "cap.image-gen": {
+      "description": "AI-powered image generation",
+      "providers": [
+        "uramaki.comfyui",
+        "uramaki.automatic1111"
+      ],
+      "interface": "Prompt to image API"
+    },
+    "cap.media-processing": {
+      "description": "Audio and video processing capabilities",
+      "providers": [
+        "uramaki.ffmpeg",
+        "uramaki.imagemagick",
+        "uramaki.remotion"
+      ],
+      "interface": "Media manipulation API"
+    },
+    "cap.workflow": {
+      "description": "Visual workflow and automation builder",
+      "providers": [
+        "hosomaki.n8n",
+        "hosomaki.temporal",
+        "temaki.windmill"
+      ],
+      "interface": "Workflow execution API"
+    },
+    "cap.reverse-proxy": {
+      "description": "HTTP server and reverse proxy",
+      "providers": [
+        "hosomaki.caddy"
+      ],
+      "interface": "HTTP/HTTPS serving"
+    },
+    "cap.monitoring": {
+      "description": "Metrics collection and monitoring",
+      "providers": [
+        "inari.prometheus"
+      ],
+      "interface": "Prometheus metrics API"
+    },
+    "cap.sso": {
+      "description": "Single sign-on and identity management",
+      "providers": [
+        "gunkanmaki.authentik",
+        "gunkanmaki.keycloak"
+      ],
+      "interface": "OIDC/SAML/OAuth2"
+    },
+    "cap.passwords": {
+      "description": "Password management and secure storage",
+      "providers": [
+        "gunkanmaki.vaultwarden"
+      ],
+      "interface": "Password manager API"
+    },
+    "cap.secrets": {
+      "description": "Secure storage and management of secrets",
+      "providers": [
+        "gunkanmaki.infisical"
+      ],
+      "interface": "Secrets API"
+    },
+    "cap.chat-ui": {
+      "description": "Web-based chat interface for LLM interaction",
+      "providers": [
+        "nigiri.open-webui",
+        "hosomaki.anythingllm"
+      ],
+      "interface": "Web UI"
+    },
+    "cap.rag-ui": {
+      "description": "RAG-enabled chat interface with document management",
+      "providers": [
+        "hosomaki.anythingllm"
+      ],
+      "interface": "Web UI with document upload"
+    },
+    "cap.dev-env": {
+      "description": "Development environment and IDE access",
+      "providers": [
+        "temaki.vscode-server"
+      ],
+      "interface": "Web-based IDE"
+    },
+    "cap.notebooks": {
+      "description": "Interactive notebook environment for data science",
+      "providers": [
+        "chirashi.jupyterlab"
+      ],
+      "interface": "Notebook interface"
+    },
+    "cap.docs-site": {
+      "description": "Documentation site generation and hosting",
+      "providers": [
+        "sashimi.docusaurus"
+      ],
+      "interface": "Static site generator"
+    },
+    "cap.dashboards": {
+      "description": "Data visualization and dashboard creation",
+      "providers": [
+        "inari.grafana",
+        "chirashi.panel",
+        "chirashi.metabase"
+      ],
+      "interface": "Dashboard web interface"
+    },
+    "cap.api-docs": {
+      "description": "API documentation and exploration",
+      "providers": [
+        "sashimi.swaggerui",
+        "sashimi.redoc"
+      ],
+      "interface": "Interactive API documentation"
+    },
+    "cap.db-admin": {
+      "description": "Database administration interface",
+      "providers": [
+        "futomaki.pgadmin",
+        "futomaki.redisinsight"
+      ],
+      "interface": "Web-based database management"
+    },
+    "cap.experiment-tracking": {
+      "description": "Machine learning experiment tracking and management",
+      "providers": [
+        "chirashi.mlflow"
+      ],
+      "interface": "ML experiment API"
+    },
+    "cap.model-serving": {
+      "description": "Model deployment and serving framework",
+      "providers": [
+        "chirashi.bentoml"
+      ],
+      "interface": "Model serving API"
+    },
+    "cap.ml-workflows": {
+      "description": "End-to-end machine learning pipeline orchestration",
+      "providers": [
+        "chirashi.kubeflow"
+      ],
+      "interface": "ML pipeline API"
+    },
+    "cap.parallel-compute": {
+      "description": "Distributed and parallel computing framework",
+      "providers": [
+        "chirashi.dask"
+      ],
+      "interface": "Distributed computing API"
+    },
+    "cap.metrics": {
+      "description": "System and application metrics collection",
+      "providers": [
+        "inari.prometheus"
+      ],
+      "interface": "Metrics scraping and storage"
+    },
+    "cap.container-metrics": {
+      "description": "Container resource monitoring and metrics",
+      "providers": [
+        "inari.cadvisor"
+      ],
+      "interface": "Container metrics API"
+    },
+    "cap.node-metrics": {
+      "description": "Host system metrics collection",
+      "providers": [
+        "inari.node-exporter"
+      ],
+      "interface": "System metrics API"
+    },
+    "cap.llm-observability": {
+      "description": "LLM-specific tracing and analytics",
+      "providers": [
+        "inari.langfuse"
+      ],
+      "interface": "LLM analytics API"
+    },
+    "cap.log-aggregation": {
+      "description": "Centralized log collection and storage",
+      "providers": [
+        "inari.loki"
+      ],
+      "interface": "Log query API"
+    },
+    "cap.log-shipping": {
+      "description": "Log collection and forwarding",
+      "providers": [
+        "inari.promtail"
+      ],
+      "interface": "Log shipping pipeline"
+    },
+    "cap.telemetry": {
+      "description": "Unified observability data collection",
+      "providers": [
+        "inari.otel-collector"
+      ],
+      "interface": "OpenTelemetry protocol"
+    },
+    "cap.git-hosting": {
+      "description": "Self-hosted Git repository management",
+      "providers": [
+        "temaki.gitea"
+      ],
+      "interface": "Git HTTP/SSH protocol"
+    },
+    "cap.code-quality": {
+      "description": "Static code analysis and quality gates",
+      "providers": [
+        "temaki.sonarqube"
+      ],
+      "interface": "Code analysis API"
+    },
+    "cap.agent-builder": {
+      "description": "Visual agent and workflow construction",
+      "providers": [
+        "temaki.flowise",
+        "temaki.dify"
+      ],
+      "interface": "Visual workflow builder"
+    },
+    "cap.ui-prototyping": {
+      "description": "Conversational UI design and prototyping",
+      "providers": [
+        "temaki.openui"
+      ],
+      "interface": "UI generation API"
+    },
+    "cap.web-search": {
+      "description": "Privacy-focused web search aggregation",
+      "providers": [
+        "otsumami.searxng"
+      ],
+      "interface": "Search API"
+    },
+    "cap.sync-tool": {
+      "description": "File synchronization and cloud integration",
+      "providers": [
+        "uramaki.rclone",
+        "futomaki.rclone-browser"
+      ],
+      "interface": "Sync and transfer API"
+    }
+  },
+  "network_profiles": {
+    "chirashi": {
+      "description": "Single network for research and development",
+      "networks": {
+        "sushi_net": {
+          "driver": "bridge",
+          "ipam": {
+            "config": [
+              {
+                "subnet": "172.20.0.0/16"
+              }
+            ]
+          }
+        }
+      },
+      "isolation_level": "none"
+    },
+    "temaki": {
+      "description": "Segmented networks for business use",
+      "networks": {
+        "sushi_frontend": {
+          "driver": "bridge",
+          "internal": false
+        },
+        "sushi_backend": {
+          "driver": "bridge",
+          "internal": true
+        },
+        "sushi_data": {
+          "driver": "bridge",
+          "internal": true
+        }
+      },
+      "isolation_level": "moderate"
+    },
+    "inari": {
+      "description": "Maximum isolation for sensitive data",
+      "networks": {
+        "sushi_public": {
+          "driver": "bridge",
+          "internal": false
+        },
+        "sushi_processing": {
+          "driver": "bridge",
+          "internal": true
+        },
+        "sushi_storage": {
+          "driver": "bridge",
+          "internal": true
+        },
+        "sushi_audit": {
+          "driver": "bridge",
+          "internal": true
+        }
+      },
+      "isolation_level": "maximum"
+    }
+  },
+  "services": {
+    "hosomaki.n8n": {
+      "name": "n8n Workflow Automation",
+      "docker": {
+        "image": "n8nio/n8n:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 5678,
+          "host_range": "5678",
+          "protocol": "tcp",
+          "description": "Web interface and API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "n8n_data",
+          "mount": "/home/node/.n8n",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "GENERIC_TIMEZONE": "${TIMEZONE:-UTC}",
+        "DB_TYPE": "postgresdb",
+        "DB_POSTGRESDB_HOST": "postgres",
+        "DB_POSTGRESDB_PORT": "5432",
+        "DB_POSTGRESDB_DATABASE": "${N8N_DB_NAME:-n8n}",
+        "DB_POSTGRESDB_USER": "${N8N_DB_USER:-n8n}",
+        "DB_POSTGRESDB_PASSWORD": "${N8N_DB_PASSWORD}",
+        "N8N_ENCRYPTION_KEY": "${N8N_ENCRYPTION_KEY}",
+        "WEBHOOK_URL": "https://${DOMAIN}/webhook/"
+      },
+      "provides": [
+        "cap.workflow"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "suggests": [
+        "cap.reverse-proxy",
+        "cap.secrets"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 512,
+        "storage_gb": 5
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "cpu_usage"
+      },
+      "healthcheck": {
+        "endpoint": "/healthz",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.litellm": {
+      "name": "LiteLLM Gateway",
+      "docker": {
+        "image": "ghcr.io/berriai/litellm:main-latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 4000,
+          "host_range": "4000",
+          "protocol": "tcp",
+          "description": "LLM proxy API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "litellm_config",
+          "mount": "/app/config",
+          "type": "bind",
+          "source": "./config/litellm"
+        }
+      ],
+      "environment": {
+        "LITELLM_MASTER_KEY": "${LITELLM_MASTER_KEY}",
+        "DATABASE_URL": "${LITELLM_DATABASE_URL}",
+        "STORE_MODEL_IN_DB": "True"
+      },
+      "provides": [
+        "cap.llm-gateway"
+      ],
+      "suggests": [
+        "cap.database",
+        "cap.redis"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 2
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 5,
+        "scale_metric": "request_rate"
+      },
+      "healthcheck": {
+        "endpoint": "/health",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.ollama": {
+      "name": "Ollama Local LLM Server",
+      "docker": {
+        "image": "ollama/ollama:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 11434,
+          "host_range": "11434",
+          "protocol": "tcp",
+          "description": "LLM inference API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "ollama_data",
+          "mount": "/root/.ollama",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "environment": {
+        "OLLAMA_HOST": "0.0.0.0",
+        "OLLAMA_MODELS": "/root/.ollama/models",
+        "OLLAMA_KEEP_ALIVE": "24h",
+        "CUDA_VISIBLE_DEVICES": "${CUDA_VISIBLE_DEVICES:-all}"
+      },
+      "provides": [
+        "cap.llm-api",
+        "cap.embeddings"
+      ],
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 50,
+        "gpu_memory_mb": 8192
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_memory"
+      },
+      "healthcheck": {
+        "endpoint": "/api/tags",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.anythingllm": {
+      "name": "AnythingLLM RAG Interface",
+      "docker": {
+        "image": "mintplexlabs/anythingllm:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3001,
+          "host_range": "3001",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "anythingllm_storage",
+          "mount": "/app/server/storage",
+          "type": "named",
+          "backup_priority": "high"
+        },
+        {
+          "name": "anythingllm_hotdir",
+          "mount": "/app/collector/hotdir",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "STORAGE_DIR": "/app/server/storage",
+        "JWT_SECRET": "${ANYTHINGLLM_JWT_SECRET}",
+        "LLM_PROVIDER": "ollama",
+        "OLLAMA_BASE_PATH": "http://ollama:11434",
+        "EMBEDDING_ENGINE": "ollama",
+        "VECTOR_DB": "qdrant",
+        "QDRANT_ENDPOINT": "http://qdrant:6333"
+      },
+      "provides": [
+        "cap.rag-ui",
+        "cap.chat-ui"
+      ],
+      "requires": [
+        "cap.llm-api",
+        "cap.vector-db"
+      ],
+      "suggests": [
+        "cap.embeddings"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "active_sessions"
+      },
+      "healthcheck": {
+        "endpoint": "/api/system",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.vllm": {
+      "name": "vLLM High-Performance Inference",
+      "docker": {
+        "image": "vllm/vllm-openai:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8000,
+          "host_range": "8000",
+          "protocol": "tcp",
+          "description": "OpenAI-compatible API"
+        }
+      ],
+      "environment": {
+        "MODEL": "${VLLM_MODEL:-microsoft/DialoGPT-medium}",
+        "TENSOR_PARALLEL_SIZE": "${VLLM_TENSOR_PARALLEL:-1}",
+        "GPU_MEMORY_UTILIZATION": "${VLLM_GPU_MEMORY:-0.9}"
+      },
+      "provides": [
+        "cap.llm-api",
+        "cap.gpu-infer"
+      ],
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 20,
+        "gpu_memory_mb": 16384
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_utilization"
+      },
+      "healthcheck": {
+        "endpoint": "/health",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.caddy": {
+      "name": "Caddy Web Server",
+      "docker": {
+        "image": "caddy:2-alpine",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 80,
+          "host_range": "80",
+          "protocol": "tcp",
+          "description": "HTTP"
+        },
+        {
+          "container": 443,
+          "host_range": "443",
+          "protocol": "tcp",
+          "description": "HTTPS"
+        },
+        {
+          "container": 2019,
+          "host_range": "2019",
+          "protocol": "tcp",
+          "description": "Admin API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "caddy_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        },
+        {
+          "name": "caddy_config",
+          "mount": "/config",
+          "type": "named"
+        },
+        {
+          "name": "caddy_caddyfile",
+          "mount": "/etc/caddy/Caddyfile",
+          "type": "bind",
+          "source": "./config/caddy/Caddyfile"
+        }
+      ],
+      "environment": {
+        "DOMAIN": "${DOMAIN}",
+        "EMAIL": "${SSL_EMAIL}"
+      },
+      "provides": [
+        "cap.reverse-proxy"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 256,
+        "storage_gb": 1
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "connection_count"
+      },
+      "healthcheck": {
+        "endpoint": "/health",
+        "interval": "30s",
+        "timeout": "5s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "hosomaki.tgi": {
+      "name": "Text Generation Inference (TGI)",
+      "docker": {
+        "image": "ghcr.io/huggingface/text-generation-inference:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 80,
+          "host_range": "8080",
+          "protocol": "tcp",
+          "description": "Inference API"
+        }
+      ],
+      "environment": {
+        "MODEL_ID": "${TGI_MODEL_ID}",
+        "NUM_SHARD": "${TGI_NUM_SHARD:-1}",
+        "MAX_CONCURRENT_REQUESTS": "${TGI_MAX_CONCURRENT:-128}",
+        "CUDA_VISIBLE_DEVICES": "${CUDA_VISIBLE_DEVICES:-all}"
+      },
+      "provides": [
+        "cap.gpu-infer"
+      ],
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 50,
+        "gpu_memory_mb": 16384
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_utilization"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.triton": {
+      "name": "NVIDIA Triton Inference Server",
+      "docker": {
+        "image": "nvcr.io/nvidia/tritonserver:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8000,
+          "host_range": "8001",
+          "protocol": "tcp",
+          "description": "HTTP API"
+        },
+        {
+          "container": 8001,
+          "host_range": "8002",
+          "protocol": "tcp",
+          "description": "gRPC API"
+        },
+        {
+          "container": 8002,
+          "host_range": "8003",
+          "protocol": "tcp",
+          "description": "Metrics"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "triton_models",
+          "mount": "/models",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "command": [
+        "tritonserver",
+        "--model-repository=/models"
+      ],
+      "provides": [
+        "cap.gpu-infer"
+      ],
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 100,
+        "gpu_memory_mb": 24576
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_utilization"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "hosomaki.temporal": {
+      "name": "Temporal Workflow Engine",
+      "docker": {
+        "image": "temporalio/auto-setup:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "hosomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 7233,
+          "host_range": "7233",
+          "protocol": "tcp",
+          "description": "gRPC API"
+        },
+        {
+          "container": 8233,
+          "host_range": "8233",
+          "protocol": "tcp",
+          "description": "Web UI"
+        }
+      ],
+      "environment": {
+        "DB": "postgresql",
+        "DB_PORT": "5432",
+        "POSTGRES_USER": "${POSTGRES_USER:-temporal}",
+        "POSTGRES_PWD": "${TEMPORAL_DB_PASSWORD}",
+        "POSTGRES_SEEDS": "postgres"
+      },
+      "provides": [
+        "cap.workflow"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "futomaki.supabase": {
+      "name": "Supabase Backend-as-a-Service",
+      "docker": {
+        "image": "supabase/supabase:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3010",
+          "protocol": "tcp",
+          "description": "Dashboard"
+        },
+        {
+          "container": 8000,
+          "host_range": "8010",
+          "protocol": "tcp",
+          "description": "API Gateway"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "supabase_data",
+          "mount": "/var/lib/postgresql/data",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "POSTGRES_PASSWORD": "${SUPABASE_DB_PASSWORD}",
+        "JWT_SECRET": "${SUPABASE_JWT_SECRET}",
+        "ANON_KEY": "${SUPABASE_ANON_KEY}",
+        "SERVICE_ROLE_KEY": "${SUPABASE_SERVICE_KEY}"
+      },
+      "provides": [
+        "cap.database",
+        "cap.sso"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 100
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.postgres": {
+      "name": "PostgreSQL Database",
+      "docker": {
+        "image": "pgvector/pgvector:pg15",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 5432,
+          "host_range": "5432",
+          "protocol": "tcp",
+          "description": "PostgreSQL"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "postgres_data",
+          "mount": "/var/lib/postgresql/data",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "POSTGRES_DB": "${POSTGRES_DB:-sushi}",
+        "POSTGRES_USER": "${POSTGRES_USER:-sushi}",
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+        "PGDATA": "/var/lib/postgresql/data/pgdata"
+      },
+      "provides": [
+        "cap.database",
+        "cap.vector-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 50
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_metric": "none"
+      },
+      "healthcheck": {
+        "command": [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-sushi}"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.redis": {
+      "name": "Redis Cache",
+      "docker": {
+        "image": "redis:7-alpine",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 6379,
+          "host_range": "6379",
+          "protocol": "tcp",
+          "description": "Redis"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "redis_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "low"
+        }
+      ],
+      "environment": {
+        "REDIS_PASSWORD": "${REDIS_PASSWORD}"
+      },
+      "command": [
+        "redis-server",
+        "--requirepass",
+        "${REDIS_PASSWORD}"
+      ],
+      "provides": [
+        "cap.redis"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "memory_usage"
+      },
+      "healthcheck": {
+        "command": [
+          "CMD",
+          "redis-cli",
+          "ping"
+        ],
+        "interval": "30s",
+        "timeout": "3s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_processing",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.qdrant": {
+      "name": "Qdrant Vector Database",
+      "docker": {
+        "image": "qdrant/qdrant:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 6333,
+          "host_range": "6333",
+          "protocol": "tcp",
+          "description": "REST API"
+        },
+        {
+          "container": 6334,
+          "host_range": "6334",
+          "protocol": "tcp",
+          "description": "gRPC API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "qdrant_storage",
+          "mount": "/qdrant/storage",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "QDRANT__SERVICE__HTTP_PORT": "6333",
+        "QDRANT__SERVICE__GRPC_PORT": "6334",
+        "QDRANT__LOG_LEVEL": "INFO"
+      },
+      "provides": [
+        "cap.vector-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 100
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "memory_usage"
+      },
+      "healthcheck": {
+        "endpoint": "/health",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_processing",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.weaviate": {
+      "name": "Weaviate Vector Database",
+      "docker": {
+        "image": "semitechnologies/weaviate:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8020",
+          "protocol": "tcp",
+          "description": "GraphQL API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "weaviate_data",
+          "mount": "/var/lib/weaviate",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "QUERY_DEFAULTS_LIMIT": "25",
+        "AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED": "true",
+        "PERSISTENCE_DATA_PATH": "/var/lib/weaviate"
+      },
+      "provides": [
+        "cap.vector-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 100
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "memory_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_processing",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.chroma": {
+      "name": "Chroma Vector Store",
+      "docker": {
+        "image": "chromadb/chroma:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8000,
+          "host_range": "8030",
+          "protocol": "tcp",
+          "description": "HTTP API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "chroma_data",
+          "mount": "/chroma/chroma",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "provides": [
+        "cap.vector-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 50
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "memory_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_processing",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.infinity": {
+      "name": "Infinity Embedding Server",
+      "docker": {
+        "image": "michaelf34/infinity:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 7997,
+          "host_range": "7997",
+          "protocol": "tcp",
+          "description": "Embedding API"
+        }
+      ],
+      "environment": {
+        "MODEL_ID": "${INFINITY_MODEL_ID:-BAAI/bge-small-en-v1.5}"
+      },
+      "provides": [
+        "cap.embeddings"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "futomaki.neo4j": {
+      "name": "Neo4j Graph Database",
+      "docker": {
+        "image": "neo4j:5-community",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 7474,
+          "host_range": "7474",
+          "protocol": "tcp",
+          "description": "HTTP interface"
+        },
+        {
+          "container": 7687,
+          "host_range": "7687",
+          "protocol": "tcp",
+          "description": "Bolt protocol"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "neo4j_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "critical"
+        },
+        {
+          "name": "neo4j_logs",
+          "mount": "/logs",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD}",
+        "NEO4J_PLUGINS": "[\"apoc\", \"n10s\"]"
+      },
+      "provides": [
+        "cap.graph-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 100
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_metric": "none"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_processing",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.minio": {
+      "name": "MinIO Object Storage",
+      "docker": {
+        "image": "minio/minio:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9000,
+          "host_range": "9000",
+          "protocol": "tcp",
+          "description": "S3 API"
+        },
+        {
+          "container": 9001,
+          "host_range": "9001",
+          "protocol": "tcp",
+          "description": "Console"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "minio_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "MINIO_ROOT_USER": "${MINIO_ROOT_USER:-admin}",
+        "MINIO_ROOT_PASSWORD": "${MINIO_ROOT_PASSWORD}",
+        "MINIO_DOMAIN": "${DOMAIN}"
+      },
+      "command": [
+        "server",
+        "/data",
+        "--console-address",
+        ":9001"
+      ],
+      "provides": [
+        "cap.object-storage"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 200
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "storage_usage"
+      },
+      "healthcheck": {
+        "command": [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:9000/minio/health/live"
+        ],
+        "interval": "30s",
+        "timeout": "20s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend",
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.restic": {
+      "name": "Restic Backup System",
+      "docker": {
+        "image": "restic/restic:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "restic_repo",
+          "mount": "/repo",
+          "type": "named",
+          "backup_priority": "critical"
+        },
+        {
+          "name": "restic_cache",
+          "mount": "/cache",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "RESTIC_REPOSITORY": "/repo",
+        "RESTIC_PASSWORD": "${RESTIC_PASSWORD}"
+      },
+      "provides": [
+        "cap.backup"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 512,
+        "storage_gb": 100
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_data"
+        ],
+        "inari": [
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.pgadmin": {
+      "name": "pgAdmin Database Management",
+      "docker": {
+        "image": "dpage/pgadmin4:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 80,
+          "host_range": "5050",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "pgadmin_data",
+          "mount": "/var/lib/pgadmin",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "environment": {
+        "PGADMIN_DEFAULT_EMAIL": "${PGADMIN_EMAIL}",
+        "PGADMIN_DEFAULT_PASSWORD": "${PGADMIN_PASSWORD}"
+      },
+      "provides": [
+        "cap.db-admin"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 512,
+        "storage_gb": 2
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_storage"
+        ]
+      }
+    },
+    "futomaki.redisinsight": {
+      "name": "RedisInsight Management UI",
+      "docker": {
+        "image": "redislabs/redisinsight:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8001,
+          "host_range": "8040",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "redisinsight_data",
+          "mount": "/db",
+          "type": "named"
+        }
+      ],
+      "provides": [
+        "cap.db-admin"
+      ],
+      "requires": [
+        "cap.redis"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 256,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "futomaki.rclone-browser": {
+      "name": "Rclone Browser GUI",
+      "docker": {
+        "image": "rclone/rclone:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "futomaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 5572,
+          "host_range": "5572",
+          "protocol": "tcp",
+          "description": "Web GUI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "rclone_config",
+          "mount": "/config/rclone",
+          "type": "named"
+        }
+      ],
+      "command": [
+        "rclone",
+        "rcd",
+        "--rc-web-gui",
+        "--rc-addr",
+        ":5572"
+      ],
+      "provides": [
+        "cap.sync-tool"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 256,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "nigiri.whisper": {
+      "name": "Whisper STT Service",
+      "docker": {
+        "image": "onerahmet/openai-whisper-asr-webservice:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "nigiri"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9000,
+          "host_range": "9010",
+          "protocol": "tcp",
+          "description": "Whisper API"
+        }
+      ],
+      "environment": {
+        "ASR_MODEL": "base",
+        "ASR_ENGINE": "openai_whisper"
+      },
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "provides": [
+        "cap.asr"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 10,
+        "gpu_memory_mb": 4096
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_utilization"
+      },
+      "healthcheck": {
+        "endpoint": "/health",
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "nigiri.piper": {
+      "name": "Piper TTS Service",
+      "docker": {
+        "image": "rhasspy/piper:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "nigiri"
+        ]
+      },
+      "ports": [
+        {
+          "container": 10200,
+          "host_range": "10200",
+          "protocol": "tcp",
+          "description": "TTS API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "piper_models",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "provides": [
+        "cap.tts"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "nigiri.openvoice": {
+      "name": "OpenVoice Voice Cloning",
+      "docker": {
+        "image": "myshell/openvoice:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "nigiri"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8000,
+          "host_range": "8050",
+          "protocol": "tcp",
+          "description": "Voice cloning API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "openvoice_models",
+          "mount": "/models",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "provides": [
+        "cap.tts"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 15,
+        "gpu_memory_mb": 8192
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_utilization"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "nigiri.open-webui": {
+      "name": "Open WebUI Chat Interface",
+      "docker": {
+        "image": "ghcr.io/open-webui/open-webui:main",
+        "platform": "linux/amd64",
+        "profiles": [
+          "nigiri"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8060",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "openwebui_data",
+          "mount": "/app/backend/data",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "OLLAMA_BASE_URL": "http://ollama:11434",
+        "WEBUI_SECRET_KEY": "${OPENWEBUI_SECRET_KEY}"
+      },
+      "provides": [
+        "cap.chat-ui"
+      ],
+      "requires": [
+        "cap.llm-api"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "active_sessions"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.comfyui": {
+      "name": "ComfyUI Image Generation",
+      "docker": {
+        "image": "yanwk/comfyui-boot:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8188,
+          "host_range": "8188",
+          "protocol": "tcp",
+          "description": "ComfyUI Interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "comfyui_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "environment": {
+        "CLI_ARGS": "--listen --port 8188"
+      },
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "provides": [
+        "cap.image-gen"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 100,
+        "gpu_memory_mb": 12288
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_memory"
+      },
+      "healthcheck": {
+        "endpoint": "/system_stats",
+        "interval": "60s",
+        "timeout": "10s",
+        "retries": 3
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.automatic1111": {
+      "name": "Automatic1111 Stable Diffusion",
+      "docker": {
+        "image": "automaticai/automatic1111:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 7860,
+          "host_range": "7860",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "automatic1111_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "environment": {
+        "CLI_ARGS": "--listen --port 7860"
+      },
+      "device_requests": [
+        {
+          "driver": "nvidia",
+          "count": "all",
+          "capabilities": [
+            "gpu"
+          ]
+        }
+      ],
+      "provides": [
+        "cap.image-gen"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 100,
+        "gpu_memory_mb": 12288
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "gpu_memory"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.ffmpeg": {
+      "name": "FFmpeg Media Processing",
+      "docker": {
+        "image": "linuxserver/ffmpeg:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "ffmpeg_input",
+          "mount": "/input",
+          "type": "named"
+        },
+        {
+          "name": "ffmpeg_output",
+          "mount": "/output",
+          "type": "named"
+        }
+      ],
+      "provides": [
+        "cap.media-processing"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 2048,
+        "storage_gb": 20
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.imagemagick": {
+      "name": "ImageMagick Image Processing",
+      "docker": {
+        "image": "dpokidov/imagemagick:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "imagemagick_input",
+          "mount": "/input",
+          "type": "named"
+        },
+        {
+          "name": "imagemagick_output",
+          "mount": "/output",
+          "type": "named"
+        }
+      ],
+      "provides": [
+        "cap.media-processing"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 10
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.rclone": {
+      "name": "Rclone File Sync",
+      "docker": {
+        "image": "rclone/rclone:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "rclone_data",
+          "mount": "/data",
+          "type": "named"
+        },
+        {
+          "name": "rclone_config",
+          "mount": "/config/rclone",
+          "type": "named"
+        }
+      ],
+      "provides": [
+        "cap.sync-tool"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 512,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "uramaki.remotion": {
+      "name": "Remotion Video Creation",
+      "docker": {
+        "image": "remotion/renderer:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "uramaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3020",
+          "protocol": "tcp",
+          "description": "Studio interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "remotion_projects",
+          "mount": "/projects",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "provides": [
+        "cap.media-processing"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 50
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.jupyterlab": {
+      "name": "JupyterLab Data Science",
+      "docker": {
+        "image": "jupyter/datascience-notebook:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8888,
+          "host_range": "8888",
+          "protocol": "tcp",
+          "description": "Jupyter interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "jupyter_work",
+          "mount": "/home/jovyan/work",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "JUPYTER_ENABLE_LAB": "yes",
+        "JUPYTER_TOKEN": "${JUPYTER_TOKEN}"
+      },
+      "provides": [
+        "cap.notebooks"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 20
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.panel": {
+      "name": "Panel Dashboard Framework",
+      "docker": {
+        "image": "pyviz/panel:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 5006,
+          "host_range": "5006",
+          "protocol": "tcp",
+          "description": "Panel server"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "panel_apps",
+          "mount": "/apps",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "provides": [
+        "cap.dashboards"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.dask": {
+      "name": "Dask Distributed Computing",
+      "docker": {
+        "image": "daskdev/dask:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8787,
+          "host_range": "8787",
+          "protocol": "tcp",
+          "description": "Dashboard"
+        },
+        {
+          "container": 8786,
+          "host_range": "8786",
+          "protocol": "tcp",
+          "description": "Scheduler"
+        }
+      ],
+      "provides": [
+        "cap.parallel-compute"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 20
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 5,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.mlflow": {
+      "name": "MLflow Experiment Tracking",
+      "docker": {
+        "image": "mlflow/mlflow:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 5000,
+          "host_range": "5000",
+          "protocol": "tcp",
+          "description": "MLflow UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "mlflow_data",
+          "mount": "/mlflow",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "BACKEND_STORE_URI": "postgresql://mlflow:${MLFLOW_DB_PASSWORD}@postgres:5432/mlflow",
+        "DEFAULT_ARTIFACT_ROOT": "s3://mlflow"
+      },
+      "provides": [
+        "cap.experiment-tracking"
+      ],
+      "requires": [
+        "cap.database",
+        "cap.object-storage"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.bentoml": {
+      "name": "BentoML Model Serving",
+      "docker": {
+        "image": "bentoml/model-server:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3030",
+          "protocol": "tcp",
+          "description": "Model API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "bentoml_models",
+          "mount": "/models",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "provides": [
+        "cap.model-serving"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 50
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 5,
+        "scale_metric": "request_rate"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.kubeflow": {
+      "name": "Kubeflow ML Workflows",
+      "docker": {
+        "image": "kubeflownotebookswg/jupyter-scipy:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8070",
+          "protocol": "tcp",
+          "description": "Kubeflow UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "kubeflow_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "provides": [
+        "cap.ml-workflows"
+      ],
+      "requires": [
+        "cap.database",
+        "cap.object-storage"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 4,
+        "memory_mb": 8192,
+        "storage_gb": 100
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "chirashi.metabase": {
+      "name": "Metabase Analytics",
+      "docker": {
+        "image": "metabase/metabase:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "chirashi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3040",
+          "protocol": "tcp",
+          "description": "Metabase UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "metabase_data",
+          "mount": "/metabase-data",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "MB_DB_TYPE": "postgres",
+        "MB_DB_DBNAME": "metabase",
+        "MB_DB_PORT": "5432",
+        "MB_DB_USER": "metabase",
+        "MB_DB_PASS": "${METABASE_DB_PASSWORD}",
+        "MB_DB_HOST": "postgres"
+      },
+      "provides": [
+        "cap.dashboards"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 10
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.vscode-server": {
+      "name": "VS Code Server",
+      "docker": {
+        "image": "codercom/code-server:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8080",
+          "protocol": "tcp",
+          "description": "VS Code interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "vscode_projects",
+          "mount": "/home/coder/projects",
+          "type": "named",
+          "backup_priority": "high"
+        },
+        {
+          "name": "vscode_extensions",
+          "mount": "/home/coder/.local/share/code-server",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "PASSWORD": "${VSCODE_PASSWORD}"
+      },
+      "provides": [
+        "cap.dev-env"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 2048,
+        "storage_gb": 20
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "active_sessions"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.gitea": {
+      "name": "Gitea Git Service",
+      "docker": {
+        "image": "gitea/gitea:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3050",
+          "protocol": "tcp",
+          "description": "Web interface"
+        },
+        {
+          "container": 22,
+          "host_range": "2222",
+          "protocol": "tcp",
+          "description": "SSH Git"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "gitea_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "critical"
+        },
+        {
+          "name": "gitea_config",
+          "mount": "/etc/gitea",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "USER_UID": "1000",
+        "USER_GID": "1000",
+        "GITEA__database__DB_TYPE": "postgres",
+        "GITEA__database__HOST": "postgres:5432",
+        "GITEA__database__NAME": "gitea",
+        "GITEA__database__USER": "gitea",
+        "GITEA__database__PASSWD": "${GITEA_DB_PASSWORD}"
+      },
+      "provides": [
+        "cap.git-hosting"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 50
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.sonarqube": {
+      "name": "SonarQube Code Quality",
+      "docker": {
+        "image": "sonarqube:community",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9000,
+          "host_range": "9030",
+          "protocol": "tcp",
+          "description": "Web interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "sonarqube_data",
+          "mount": "/opt/sonarqube/data",
+          "type": "named",
+          "backup_priority": "medium"
+        },
+        {
+          "name": "sonarqube_extensions",
+          "mount": "/opt/sonarqube/extensions",
+          "type": "named"
+        },
+        {
+          "name": "sonarqube_logs",
+          "mount": "/opt/sonarqube/logs",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "SONAR_JDBC_URL": "jdbc:postgresql://postgres:5432/sonarqube",
+        "SONAR_JDBC_USERNAME": "sonarqube",
+        "SONAR_JDBC_PASSWORD": "${SONARQUBE_DB_PASSWORD}"
+      },
+      "provides": [
+        "cap.code-quality"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 20
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.flowise": {
+      "name": "Flowise Visual Agent Builder",
+      "docker": {
+        "image": "flowiseai/flowise:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3060",
+          "protocol": "tcp",
+          "description": "Flowise interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "flowise_data",
+          "mount": "/root/.flowise",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "DATABASE_PATH": "/root/.flowise",
+        "APIKEY_PATH": "/root/.flowise",
+        "LOG_LEVEL": "info"
+      },
+      "provides": [
+        "cap.agent-builder"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.dify": {
+      "name": "Dify Assistant Builder",
+      "docker": {
+        "image": "langgenius/dify-web:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3070",
+          "protocol": "tcp",
+          "description": "Dify interface"
+        }
+      ],
+      "environment": {
+        "NEXT_PUBLIC_API_PREFIX": "${DIFY_API_URL}",
+        "NEXT_PUBLIC_PUBLIC_API_PREFIX": "${DIFY_PUBLIC_API_URL}"
+      },
+      "provides": [
+        "cap.agent-builder"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.windmill": {
+      "name": "Windmill Workflow Engine",
+      "docker": {
+        "image": "ghcr.io/windmill-labs/windmill:main",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8000,
+          "host_range": "8090",
+          "protocol": "tcp",
+          "description": "Windmill interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "windmill_data",
+          "mount": "/tmp/windmill",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "DATABASE_URL": "postgresql://windmill:${WINDMILL_DB_PASSWORD}@postgres:5432/windmill",
+        "BASE_URL": "http://localhost:8090"
+      },
+      "provides": [
+        "cap.workflow"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 2048,
+        "storage_gb": 10
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "temaki.openui": {
+      "name": "OpenUI Interface Builder",
+      "docker": {
+        "image": "ghcr.io/wandb/openui:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "temaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 7878,
+          "host_range": "7878",
+          "protocol": "tcp",
+          "description": "OpenUI interface"
+        }
+      ],
+      "provides": [
+        "cap.ui-prototyping"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "inari.prometheus": {
+      "name": "Prometheus Metrics",
+      "docker": {
+        "image": "prom/prometheus:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9090,
+          "host_range": "9090",
+          "protocol": "tcp",
+          "description": "Prometheus UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "prometheus_data",
+          "mount": "/prometheus",
+          "type": "named",
+          "backup_priority": "medium"
+        },
+        {
+          "name": "prometheus_config",
+          "mount": "/etc/prometheus/prometheus.yml",
+          "type": "bind",
+          "source": "./config/prometheus/prometheus.yml"
+        }
+      ],
+      "command": [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        "--storage.tsdb.path=/prometheus",
+        "--web.console.libraries=/etc/prometheus/console_libraries",
+        "--web.console.templates=/etc/prometheus/consoles",
+        "--storage.tsdb.retention.time=200h",
+        "--web.enable-lifecycle"
+      ],
+      "provides": [
+        "cap.monitoring",
+        "cap.metrics"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 50
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_metric": "none"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.grafana": {
+      "name": "Grafana Dashboards",
+      "docker": {
+        "image": "grafana/grafana:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3000",
+          "protocol": "tcp",
+          "description": "Grafana UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "grafana_data",
+          "mount": "/var/lib/grafana",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "environment": {
+        "GF_SECURITY_ADMIN_PASSWORD": "${GRAFANA_ADMIN_PASSWORD}",
+        "GF_USERS_ALLOW_SIGN_UP": "false"
+      },
+      "requires": [
+        "cap.monitoring"
+      ],
+      "provides": [
+        "cap.dashboards"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 10
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "active_users"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.langfuse": {
+      "name": "Langfuse LLM Analytics",
+      "docker": {
+        "image": "langfuse/langfuse:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3080",
+          "protocol": "tcp",
+          "description": "Langfuse UI"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "langfuse_data",
+          "mount": "/app/data",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "environment": {
+        "DATABASE_URL": "postgresql://langfuse:${LANGFUSE_DB_PASSWORD}@postgres:5432/langfuse",
+        "NEXTAUTH_SECRET": "${LANGFUSE_SECRET}",
+        "SALT": "${LANGFUSE_SALT}"
+      },
+      "provides": [
+        "cap.llm-observability"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 20
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.cadvisor": {
+      "name": "cAdvisor Container Metrics",
+      "docker": {
+        "image": "gcr.io/cadvisor/cadvisor:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8100",
+          "protocol": "tcp",
+          "description": "cAdvisor interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "cadvisor_root",
+          "mount": "/rootfs",
+          "type": "bind",
+          "source": "/",
+          "read_only": true
+        },
+        {
+          "name": "cadvisor_var_run",
+          "mount": "/var/run",
+          "type": "bind",
+          "source": "/var/run",
+          "read_only": true
+        },
+        {
+          "name": "cadvisor_sys",
+          "mount": "/sys",
+          "type": "bind",
+          "source": "/sys",
+          "read_only": true
+        },
+        {
+          "name": "cadvisor_docker",
+          "mount": "/var/lib/docker",
+          "type": "bind",
+          "source": "/var/lib/docker",
+          "read_only": true
+        },
+        {
+          "name": "cadvisor_dev_disk",
+          "mount": "/dev/disk",
+          "type": "bind",
+          "source": "/dev/disk",
+          "read_only": true
+        }
+      ],
+      "provides": [
+        "cap.container-metrics"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 512,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.node-exporter": {
+      "name": "Node Exporter System Metrics",
+      "docker": {
+        "image": "prom/node-exporter:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9100,
+          "host_range": "9100",
+          "protocol": "tcp",
+          "description": "Metrics endpoint"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "node_exporter_proc",
+          "mount": "/host/proc",
+          "type": "bind",
+          "source": "/proc",
+          "read_only": true
+        },
+        {
+          "name": "node_exporter_sys",
+          "mount": "/host/sys",
+          "type": "bind",
+          "source": "/sys",
+          "read_only": true
+        },
+        {
+          "name": "node_exporter_root",
+          "mount": "/rootfs",
+          "type": "bind",
+          "source": "/",
+          "read_only": true
+        }
+      ],
+      "command": [
+        "--path.procfs=/host/proc",
+        "--path.rootfs=/rootfs",
+        "--path.sysfs=/host/sys",
+        "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+      ],
+      "provides": [
+        "cap.node-metrics"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.1,
+        "memory_mb": 128,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.loki": {
+      "name": "Loki Log Aggregation",
+      "docker": {
+        "image": "grafana/loki:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3100,
+          "host_range": "3100",
+          "protocol": "tcp",
+          "description": "Loki API"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "loki_data",
+          "mount": "/loki",
+          "type": "named",
+          "backup_priority": "medium"
+        },
+        {
+          "name": "loki_config",
+          "mount": "/etc/loki/local-config.yaml",
+          "type": "bind",
+          "source": "./config/loki/loki.yml"
+        }
+      ],
+      "provides": [
+        "cap.log-aggregation"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 50
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.promtail": {
+      "name": "Promtail Log Shipper",
+      "docker": {
+        "image": "grafana/promtail:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "promtail_config",
+          "mount": "/etc/promtail/config.yml",
+          "type": "bind",
+          "source": "./config/promtail/promtail.yml"
+        },
+        {
+          "name": "promtail_logs",
+          "mount": "/var/log",
+          "type": "bind",
+          "source": "/var/log",
+          "read_only": true
+        }
+      ],
+      "command": [
+        "-config.file=/etc/promtail/config.yml"
+      ],
+      "provides": [
+        "cap.log-shipping"
+      ],
+      "requires": [
+        "cap.log-aggregation"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.1,
+        "memory_mb": 128,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "inari.otel-collector": {
+      "name": "OpenTelemetry Collector",
+      "docker": {
+        "image": "otel/opentelemetry-collector-contrib:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "inari"
+        ]
+      },
+      "ports": [
+        {
+          "container": 4317,
+          "host_range": "4317",
+          "protocol": "tcp",
+          "description": "OTLP gRPC"
+        },
+        {
+          "container": 4318,
+          "host_range": "4318",
+          "protocol": "tcp",
+          "description": "OTLP HTTP"
+        },
+        {
+          "container": 8888,
+          "host_range": "8110",
+          "protocol": "tcp",
+          "description": "Metrics endpoint"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "otel_config",
+          "mount": "/etc/otel/config.yaml",
+          "type": "bind",
+          "source": "./config/otel/otel-collector.yml"
+        }
+      ],
+      "provides": [
+        "cap.telemetry"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_audit"
+        ]
+      }
+    },
+    "gunkanmaki.authentik": {
+      "name": "Authentik Identity Provider",
+      "docker": {
+        "image": "ghcr.io/goauthentik/authentik:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "gunkanmaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 9000,
+          "host_range": "9020",
+          "protocol": "tcp",
+          "description": "Web interface"
+        },
+        {
+          "container": 9443,
+          "host_range": "9443",
+          "protocol": "tcp",
+          "description": "HTTPS interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "authentik_media",
+          "mount": "/media",
+          "type": "named",
+          "backup_priority": "high"
+        },
+        {
+          "name": "authentik_templates",
+          "mount": "/templates",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "AUTHENTIK_SECRET_KEY": "${AUTHENTIK_SECRET_KEY}",
+        "AUTHENTIK_BOOTSTRAP_PASSWORD": "${AUTHENTIK_BOOTSTRAP_PASSWORD}",
+        "AUTHENTIK_BOOTSTRAP_TOKEN": "${AUTHENTIK_BOOTSTRAP_TOKEN}",
+        "AUTHENTIK_POSTGRESQL__HOST": "postgres",
+        "AUTHENTIK_POSTGRESQL__NAME": "${AUTHENTIK_DB_NAME:-authentik}",
+        "AUTHENTIK_POSTGRESQL__USER": "${AUTHENTIK_DB_USER:-authentik}",
+        "AUTHENTIK_POSTGRESQL__PASSWORD": "${AUTHENTIK_DB_PASSWORD}",
+        "AUTHENTIK_REDIS__HOST": "redis",
+        "AUTHENTIK_REDIS__PASSWORD": "${REDIS_PASSWORD}"
+      },
+      "requires": [
+        "cap.database",
+        "cap.redis"
+      ],
+      "provides": [
+        "cap.sso"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 5
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 3,
+        "scale_metric": "active_sessions"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "gunkanmaki.keycloak": {
+      "name": "Keycloak Identity Server",
+      "docker": {
+        "image": "quay.io/keycloak/keycloak:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "gunkanmaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8120",
+          "protocol": "tcp",
+          "description": "Keycloak interface"
+        }
+      ],
+      "environment": {
+        "KC_DB": "postgres",
+        "KC_DB_URL": "jdbc:postgresql://postgres:5432/keycloak",
+        "KC_DB_USERNAME": "keycloak",
+        "KC_DB_PASSWORD": "${KEYCLOAK_DB_PASSWORD}",
+        "KC_HOSTNAME": "${KEYCLOAK_HOSTNAME}",
+        "KEYCLOAK_ADMIN": "${KEYCLOAK_ADMIN}",
+        "KEYCLOAK_ADMIN_PASSWORD": "${KEYCLOAK_ADMIN_PASSWORD}"
+      },
+      "command": [
+        "start",
+        "--optimized"
+      ],
+      "provides": [
+        "cap.sso"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_mb": 4096,
+        "storage_gb": 10
+      },
+      "scaling": {
+        "min_replicas": 1,
+        "max_replicas": 2,
+        "scale_metric": "cpu_usage"
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "gunkanmaki.vaultwarden": {
+      "name": "Vaultwarden Password Manager",
+      "docker": {
+        "image": "vaultwarden/server:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "gunkanmaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 80,
+          "host_range": "8130",
+          "protocol": "tcp",
+          "description": "Web vault"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "vaultwarden_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "ADMIN_TOKEN": "${VAULTWARDEN_ADMIN_TOKEN}",
+        "WEBSOCKET_ENABLED": "true",
+        "DATABASE_URL": "postgresql://vaultwarden:${VAULTWARDEN_DB_PASSWORD}@postgres:5432/vaultwarden"
+      },
+      "provides": [
+        "cap.passwords"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 512,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "gunkanmaki.infisical": {
+      "name": "Infisical Secrets Manager",
+      "docker": {
+        "image": "infisical/infisical:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "gunkanmaki"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8140",
+          "protocol": "tcp",
+          "description": "Infisical interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "infisical_data",
+          "mount": "/app/data",
+          "type": "named",
+          "backup_priority": "critical"
+        }
+      ],
+      "environment": {
+        "DB_CONNECTION_URI": "postgresql://infisical:${INFISICAL_DB_PASSWORD}@postgres:5432/infisical",
+        "ENCRYPTION_KEY": "${INFISICAL_ENCRYPTION_KEY}",
+        "JWT_SIGNUP_SECRET": "${INFISICAL_JWT_SECRET}",
+        "JWT_REFRESH_SECRET": "${INFISICAL_JWT_REFRESH_SECRET}",
+        "JWT_AUTH_SECRET": "${INFISICAL_JWT_AUTH_SECRET}"
+      },
+      "provides": [
+        "cap.secrets"
+      ],
+      "requires": [
+        "cap.database"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public",
+          "sushi_processing"
+        ]
+      }
+    },
+    "sashimi.docusaurus": {
+      "name": "Docusaurus Documentation Site",
+      "docker": {
+        "image": "node:18-alpine",
+        "platform": "linux/amd64",
+        "profiles": [
+          "sashimi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 3000,
+          "host_range": "3090",
+          "protocol": "tcp",
+          "description": "Docusaurus site"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "docusaurus_site",
+          "mount": "/app",
+          "type": "named",
+          "backup_priority": "high"
+        }
+      ],
+      "working_dir": "/app",
+      "command": [
+        "npm",
+        "start",
+        "--",
+        "--host",
+        "0.0.0.0"
+      ],
+      "provides": [
+        "cap.docs-site"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 5
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "sashimi.swaggerui": {
+      "name": "Swagger UI API Explorer",
+      "docker": {
+        "image": "swaggerapi/swagger-ui:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "sashimi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8150",
+          "protocol": "tcp",
+          "description": "Swagger UI"
+        }
+      ],
+      "environment": {
+        "SWAGGER_JSON": "/openapi.json",
+        "BASE_URL": "/swagger"
+      },
+      "volumes": [
+        {
+          "name": "swagger_specs",
+          "mount": "/usr/share/nginx/html/specs",
+          "type": "named"
+        }
+      ],
+      "provides": [
+        "cap.api-docs"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 256,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "sashimi.redoc": {
+      "name": "ReDoc API Documentation",
+      "docker": {
+        "image": "redocly/redoc:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "sashimi"
+        ]
+      },
+      "ports": [
+        {
+          "container": 80,
+          "host_range": "8160",
+          "protocol": "tcp",
+          "description": "ReDoc interface"
+        }
+      ],
+      "environment": {
+        "SPEC_URL": "/openapi.json"
+      },
+      "provides": [
+        "cap.api-docs"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 256,
+        "storage_gb": 1
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    },
+    "otsumami.duckdb": {
+      "name": "DuckDB Analytics Database",
+      "docker": {
+        "image": "duckdb/duckdb:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "otsumami"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "duckdb_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "provides": [
+        "cap.analytics-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 2048,
+        "storage_gb": 50
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "otsumami.sqlite": {
+      "name": "SQLite Embedded Database",
+      "docker": {
+        "image": "nouchka/sqlite3:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "otsumami"
+        ]
+      },
+      "volumes": [
+        {
+          "name": "sqlite_data",
+          "mount": "/data",
+          "type": "named",
+          "backup_priority": "medium"
+        }
+      ],
+      "provides": [
+        "cap.analytics-db"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 0.5,
+        "memory_mb": 512,
+        "storage_gb": 20
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_processing"
+        ]
+      }
+    },
+    "otsumami.searxng": {
+      "name": "SearXNG Privacy Search",
+      "docker": {
+        "image": "searxng/searxng:latest",
+        "platform": "linux/amd64",
+        "profiles": [
+          "otsumami"
+        ]
+      },
+      "ports": [
+        {
+          "container": 8080,
+          "host_range": "8170",
+          "protocol": "tcp",
+          "description": "Search interface"
+        }
+      ],
+      "volumes": [
+        {
+          "name": "searxng_config",
+          "mount": "/etc/searxng",
+          "type": "named"
+        }
+      ],
+      "environment": {
+        "SEARXNG_BASE_URL": "https://${DOMAIN}/search/",
+        "SEARXNG_SECRET": "${SEARXNG_SECRET}"
+      },
+      "provides": [
+        "cap.web-search"
+      ],
+      "resource_requirements": {
+        "cpu_cores": 1,
+        "memory_mb": 1024,
+        "storage_gb": 2
+      },
+      "networks": {
+        "chirashi": [
+          "sushi_net"
+        ],
+        "temaki": [
+          "sushi_frontend",
+          "sushi_backend"
+        ],
+        "inari": [
+          "sushi_public"
+        ]
+      }
+    }
+  },
+  "dependency_resolution": {
+    "auto_resolve_providers": true,
+    "prefer_lightweight": true,
+    "default_providers": {
+      "cap.vector-db": "futomaki.qdrant",
+      "cap.database": "futomaki.postgres",
+      "cap.redis": "futomaki.redis",
+      "cap.object-storage": "futomaki.minio",
+      "cap.llm-api": "hosomaki.ollama",
+      "cap.llm-gateway": "hosomaki.litellm",
+      "cap.reverse-proxy": "hosomaki.caddy",
+      "cap.monitoring": "inari.prometheus",
+      "cap.metrics": "inari.prometheus",
+      "cap.dashboards": "inari.grafana",
+      "cap.sso": "gunkanmaki.authentik",
+      "cap.passwords": "gunkanmaki.vaultwarden",
+      "cap.secrets": "gunkanmaki.infisical",
+      "cap.chat-ui": "hosomaki.anythingllm",
+      "cap.rag-ui": "hosomaki.anythingllm",
+      "cap.asr": "nigiri.whisper",
+      "cap.tts": "nigiri.piper",
+      "cap.image-gen": "uramaki.comfyui",
+      "cap.dev-env": "temaki.vscode-server",
+      "cap.notebooks": "chirashi.jupyterlab",
+      "cap.docs-site": "sashimi.docusaurus",
+      "cap.api-docs": "sashimi.swaggerui",
+      "cap.experiment-tracking": "chirashi.mlflow",
+      "cap.workflow": "hosomaki.n8n",
+      "cap.git-hosting": "temaki.gitea",
+      "cap.agent-builder": "temaki.flowise",
+      "cap.web-search": "otsumami.searxng",
+      "cap.sync-tool": "uramaki.rclone",
+      "cap.analytics-db": "otsumami.duckdb",
+      "cap.backup": "futomaki.restic",
+      "cap.db-admin": "futomaki.pgadmin",
+      "cap.gpu-infer": "hosomaki.vllm",
+      "cap.embeddings": "hosomaki.ollama",
+      "cap.media-processing": "uramaki.ffmpeg",
+      "cap.graph-db": "futomaki.neo4j",
+      "cap.container-metrics": "inari.cadvisor",
+      "cap.node-metrics": "inari.node-exporter",
+      "cap.llm-observability": "inari.langfuse",
+      "cap.log-aggregation": "inari.loki",
+      "cap.log-shipping": "inari.promtail",
+      "cap.telemetry": "inari.otel-collector",
+      "cap.code-quality": "temaki.sonarqube",
+      "cap.model-serving": "chirashi.bentoml",
+      "cap.ml-workflows": "chirashi.kubeflow",
+      "cap.parallel-compute": "chirashi.dask",
+      "cap.ui-prototyping": "temaki.openui"
+    },
+    "conflicts": [
+      {
+        "services": [
+          "futomaki.postgres",
+          "futomaki.supabase"
+        ],
+        "reason": "Both provide PostgreSQL - choose one to avoid conflicts",
+        "resolution": "Use Supabase for managed experience or PostgreSQL for full control"
+      },
+      {
+        "services": [
+          "futomaki.redis",
+          "futomaki.valkey"
+        ],
+        "reason": "Multiple cache stores unnecessary",
+        "resolution": "Use Redis for broader compatibility"
+      },
+      {
+        "services": [
+          "hosomaki.ollama",
+          "hosomaki.vllm",
+          "hosomaki.tgi"
+        ],
+        "reason": "Multiple LLM servers may compete for GPU resources",
+        "resolution": "Choose based on use case - Ollama for ease, vLLM for performance"
+      },
+      {
+        "services": [
+          "uramaki.comfyui",
+          "uramaki.automatic1111"
+        ],
+        "reason": "Both are comprehensive image generation platforms",
+        "resolution": "ComfyUI for workflows, A1111 for classic interface"
+      },
+      {
+        "services": [
+          "gunkanmaki.authentik",
+          "gunkanmaki.keycloak"
+        ],
+        "reason": "Multiple identity providers create user confusion",
+        "resolution": "Authentik for simplicity, Keycloak for enterprise features"
+      },
+      {
+        "services": [
+          "nigiri.piper",
+          "nigiri.openvoice"
+        ],
+        "reason": "Multiple TTS engines may conflict on resources",
+        "resolution": "Piper for lightweight, OpenVoice for advanced voice cloning"
+      },
+      {
+        "services": [
+          "futomaki.qdrant",
+          "futomaki.weaviate",
+          "futomaki.chroma"
+        ],
+        "reason": "Multiple vector databases create data fragmentation",
+        "resolution": "Choose one based on performance needs and integration requirements"
+      }
+    ],
+    "scaling_rules": {
+      "gpu-services": {
+        "rule": "Limit GPU services based on available VRAM and compute units",
+        "services": [
+          "hosomaki.ollama",
+          "hosomaki.vllm",
+          "hosomaki.tgi",
+          "hosomaki.triton",
+          "uramaki.comfyui",
+          "uramaki.automatic1111",
+          "nigiri.whisper",
+          "nigiri.openvoice"
+        ]
+      },
+      "storage-services": {
+        "rule": "Monitor disk usage and implement retention policies",
+        "services": [
+          "futomaki.qdrant",
+          "futomaki.postgres",
+          "futomaki.minio",
+          "futomaki.neo4j",
+          "inari.prometheus",
+          "inari.loki"
+        ]
+      },
+      "memory-intensive": {
+        "rule": "Scale based on available system memory and workload patterns",
+        "services": [
+          "chirashi.dask",
+          "chirashi.kubeflow",
+          "hosomaki.temporal",
+          "inari.grafana"
+        ]
+      },
+      "high-availability": {
+        "rule": "Critical services should have redundancy and health checks",
+        "services": [
+          "futomaki.postgres",
+          "futomaki.redis",
+          "hosomaki.caddy",
+          "gunkanmaki.authentik"
+        ]
+      }
+    }
+  },
+  "environment_templates": {
+    "development": {
+      "description": "Development environment with relaxed security and debug features",
+      "global_env": {
+        "LOG_LEVEL": "DEBUG",
+        "DEBUG_MODE": "true",
+        "SSL_VERIFY": "false",
+        "DATA_RETENTION_DAYS": "7",
+        "ENABLE_METRICS": "true",
+        "BACKUP_FREQUENCY": "daily",
+        "RESOURCE_LIMITS_ENABLED": "false"
+      },
+      "service_overrides": {
+        "hosomaki.ollama": {
+          "OLLAMA_DEBUG": "1",
+          "OLLAMA_KEEP_ALIVE": "5m"
+        },
+        "inari.grafana": {
+          "GF_USERS_ALLOW_SIGN_UP": "true",
+          "GF_AUTH_ANONYMOUS_ENABLED": "true"
+        },
+        "gunkanmaki.authentik": {
+          "AUTHENTIK_LOG_LEVEL": "debug",
+          "AUTHENTIK_ERROR_REPORTING__ENABLED": "false"
+        }
+      }
+    },
+    "production": {
+      "description": "Production environment with full security and monitoring",
+      "global_env": {
+        "LOG_LEVEL": "INFO",
+        "DEBUG_MODE": "false",
+        "SSL_VERIFY": "true",
+        "DATA_RETENTION_DAYS": "365",
+        "BACKUP_ENABLED": "true",
+        "BACKUP_FREQUENCY": "hourly",
+        "MONITORING_ENABLED": "true",
+        "RESOURCE_LIMITS_ENABLED": "true",
+        "SECURITY_SCANNING": "true"
+      },
+      "service_overrides": {
+        "hosomaki.ollama": {
+          "OLLAMA_KEEP_ALIVE": "24h",
+          "OLLAMA_MAX_LOADED_MODELS": "3"
+        },
+        "inari.grafana": {
+          "GF_USERS_ALLOW_SIGN_UP": "false",
+          "GF_AUTH_ANONYMOUS_ENABLED": "false",
+          "GF_SECURITY_ADMIN_USER": "admin"
+        },
+        "gunkanmaki.authentik": {
+          "AUTHENTIK_LOG_LEVEL": "warning",
+          "AUTHENTIK_ERROR_REPORTING__ENABLED": "true",
+          "AUTHENTIK_SECURITY__CSRF_COOKIE_SECURE": "true"
+        }
+      }
+    },
+    "compliance": {
+      "description": "Compliance-ready environment with audit logging and data protection",
+      "global_env": {
+        "LOG_LEVEL": "INFO",
+        "AUDIT_LOGGING": "true",
+        "ENCRYPTION_AT_REST": "true",
+        "DATA_RETENTION_DAYS": "2555",
+        "PII_DETECTION": "true",
+        "ANONYMIZATION": "true",
+        "BACKUP_ENCRYPTION": "true",
+        "ACCESS_LOGGING": "true",
+        "SECURITY_HEADERS": "true"
+      },
+      "service_overrides": {
+        "futomaki.postgres": {
+          "POSTGRES_AUDIT_LOG": "all",
+          "POSTGRES_SSL_MODE": "require"
+        },
+        "inari.prometheus": {
+          "PROMETHEUS_WEB_ENABLE_ADMIN_API": "false",
+          "PROMETHEUS_STORAGE_TSDB_RETENTION_TIME": "2555d"
+        },
+        "gunkanmaki.authentik": {
+          "AUTHENTIK_LOG_LEVEL": "info",
+          "AUTHENTIK_EVENTS__CONTEXT_PROCESSOR": "authentik.events.context_processors.event_context_processor",
+          "AUTHENTIK_POLICY_DEBUG_MODE": "false"
+        }
+      }
+    },
+    "edge_computing": {
+      "description": "Edge computing environment optimized for resource constraints",
+      "global_env": {
+        "LOG_LEVEL": "WARN",
+        "RESOURCE_LIMITS_ENABLED": "true",
+        "MEMORY_LIMIT_FACTOR": "0.7",
+        "CPU_LIMIT_FACTOR": "0.8",
+        "STORAGE_OPTIMIZATION": "true",
+        "COMPRESSION_ENABLED": "true",
+        "CACHE_SIZE_FACTOR": "0.5"
+      },
+      "service_overrides": {
+        "hosomaki.ollama": {
+          "OLLAMA_MAX_LOADED_MODELS": "1",
+          "OLLAMA_NUM_PARALLEL": "1"
+        },
+        "futomaki.redis": {
+          "REDIS_MAXMEMORY_POLICY": "allkeys-lru",
+          "REDIS_SAVE_FREQUENCY": "300"
+        },
+        "inari.prometheus": {
+          "PROMETHEUS_STORAGE_TSDB_RETENTION_TIME": "30d",
+          "PROMETHEUS_QUERY_MAX_SAMPLES": "50000"
+        }
+      }
+    },
+    "research_lab": {
+      "description": "Research environment with experimental features and flexible resource allocation",
+      "global_env": {
+        "LOG_LEVEL": "DEBUG",
+        "EXPERIMENTAL_FEATURES": "true",
+        "RESOURCE_LIMITS_ENABLED": "false",
+        "AUTO_SCALING": "true",
+        "MODEL_CACHING": "aggressive",
+        "DATA_RETENTION_DAYS": "90",
+        "JUPYTER_ENABLE_EXTENSIONS": "true"
+      },
+      "service_overrides": {
+        "hosomaki.ollama": {
+          "OLLAMA_EXPERIMENTAL": "true",
+          "OLLAMA_MAX_LOADED_MODELS": "10",
+          "OLLAMA_PARALLEL_REQUESTS": "4"
+        },
+        "chirashi.jupyterlab": {
+          "JUPYTER_ENABLE_LAB": "yes",
+          "JUPYTER_LAB_EXTENSIONS_PATH": "/opt/conda/share/jupyter/labextensions"
+        },
+        "uramaki.comfyui": {
+          "COMFYUI_EXPERIMENTAL_NODES": "true",
+          "COMFYUI_AUTO_INSTALL_MISSING": "true"
+        }
+      }
+    },
+    "high_security": {
+      "description": "Maximum security environment with strict access controls and monitoring",
+      "global_env": {
+        "LOG_LEVEL": "INFO",
+        "SECURITY_MODE": "strict",
+        "NETWORK_POLICIES": "deny-all",
+        "TLS_VERSION": "1.3",
+        "AUTHENTICATION_REQUIRED": "true",
+        "MFA_REQUIRED": "true",
+        "SESSION_TIMEOUT": "300",
+        "AUDIT_ALL_REQUESTS": "true"
+      },
+      "service_overrides": {
+        "gunkanmaki.authentik": {
+          "AUTHENTIK_SECURITY__CSRF_USE_SESSIONS": "true",
+          "AUTHENTIK_SECURITY__CSRF_FAILURE_VIEW": "authentik.core.views.csrf.CSRFErrorView",
+          "AUTHENTIK_POLICY_DEBUG_MODE": "false"
+        },
+        "hosomaki.caddy": {
+          "CADDY_ADMIN": "off",
+          "CADDY_HTTP_PORT": "disabled"
+        },
+        "futomaki.postgres": {
+          "POSTGRES_SSL_MODE": "require",
+          "POSTGRES_LOG_CONNECTIONS": "on",
+          "POSTGRES_LOG_DISCONNECTIONS": "on"
+        }
+      }
+    }
+  }
+}

--- a/docs/manifest/web/api/core/platters.json
+++ b/docs/manifest/web/api/core/platters.json
@@ -1,0 +1,760 @@
+{
+  "schema_version": "1.0",
+  "platters": [
+    {
+      "id": "platter.hosomaki-core",
+      "name": "Hosomaki Core",
+      "description": "Minimal foundation for testing and learning AI infrastructure basics. This platter provides the essential services needed to understand how local AI systems work together, featuring Ollama for running language models and a simple chat interface for interaction. Perfect for newcomers who want to explore AI capabilities without complexity, resource overhead, or financial commitment. The setup demonstrates core concepts of local AI inference while maintaining minimal resource requirements that work on most modern computers.",
+      "category": "foundational",
+      "target_audience": [
+        "beginners",
+        "students",
+        "hobbyists"
+      ],
+      "combos": [
+        "combo.chat-local"
+      ],
+      "additional_services": [],
+      "privacy_profile": "open_research",
+      "resource_requirements": {
+        "cpu_cores": 2,
+        "memory_gb": 4,
+        "storage_gb": 20,
+        "gpu_vram_gb": 0,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 25,
+        "hardware_onetime_usd": 400,
+        "notes": "Can run on any modern laptop or mini PC"
+      },
+      "setup_time_minutes": 10,
+      "maintenance_level": "minimal",
+      "use_cases": [
+        "Learning AI fundamentals",
+        "Testing local language models",
+        "Educational demonstrations",
+        "Resource-constrained environments"
+      ],
+      "success_criteria": [
+        "Chat with a local model through web interface",
+        "Download and switch between different model sizes",
+        "Understand basic model capabilities and limitations"
+      ],
+      "notes": "Ideal starting point before progressing to more complex deployments"
+    },
+    {
+      "id": "platter.knowledge-worker",
+      "name": "Knowledge Worker",
+      "description": "Balanced platform designed for professionals who need AI-powered knowledge management without enterprise complexity. Combines document analysis capabilities with chat interfaces and basic monitoring to create a productive AI workspace. This platter addresses the needs of consultants, researchers, and knowledge professionals who want to leverage AI for document processing, question answering, and content creation while maintaining reasonable resource requirements and setup complexity.",
+      "category": "foundational",
+      "target_audience": [
+        "consultants",
+        "researchers",
+        "knowledge-professionals",
+        "small-teams"
+      ],
+      "combos": [
+        "combo.knowledge-rag",
+        "combo.monitor-basic"
+      ],
+      "additional_services": [
+        "futomaki.minio",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 6,
+        "memory_gb": 12,
+        "storage_gb": 100,
+        "gpu_vram_gb": 0,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 150,
+        "hardware_onetime_usd": 800,
+        "notes": "Optimized for desktop workstations"
+      },
+      "setup_time_minutes": 25,
+      "maintenance_level": "low",
+      "features": [
+        "Document upload and semantic search",
+        "Multi-model LLM access (local and cloud)",
+        "Basic performance monitoring",
+        "Secure file storage",
+        "SSL termination and routing"
+      ],
+      "use_cases": [
+        "Research and analysis workflows",
+        "Document-based question answering",
+        "Content creation assistance",
+        "Professional knowledge management"
+      ],
+      "success_criteria": [
+        "Upload documents and get accurate answers",
+        "Monitor system health through dashboards",
+        "Access services through secure web interface",
+        "Store and organize work files securely"
+      ],
+      "notes": "Balanced features and resources; good for most professional use cases"
+    },
+    {
+      "id": "platter.developer-complete",
+      "name": "Developer Complete",
+      "description": "Comprehensive development environment for AI and machine learning engineers building production applications. Integrates development tools, experiment tracking, version control, and AI services to create a complete development lifecycle platform. This platter solves the challenge of maintaining consistent development environments while providing the specialized tools needed for AI application development, model experimentation, and collaborative software development.",
+      "category": "specialized",
+      "target_audience": [
+        "ml-engineers",
+        "full-stack-developers",
+        "data-scientists",
+        "development-teams"
+      ],
+      "combos": [
+        "combo.dev-workspace",
+        "combo.knowledge-rag",
+        "combo.monitor-basic"
+      ],
+      "additional_services": [
+        "chirashi.mlflow",
+        "sashimi.gitea",
+        "futomaki.minio",
+        "futomaki.pgadmin",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 8,
+        "memory_gb": 16,
+        "storage_gb": 200,
+        "gpu_vram_gb": 8,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 250,
+        "hardware_onetime_usd": 1200,
+        "notes": "GPU optional but recommended for ML workloads"
+      },
+      "setup_time_minutes": 30,
+      "maintenance_level": "medium",
+      "development_features": [
+        "Browser-based VS Code with AI extensions",
+        "JupyterLab with GPU support",
+        "Experiment tracking and model registry",
+        "Self-hosted Git with CI/CD",
+        "Database administration tools",
+        "RAG document processing capabilities"
+      ],
+      "use_cases": [
+        "AI application development",
+        "Machine learning experimentation",
+        "Data science projects",
+        "Team collaboration and code sharing"
+      ],
+      "success_criteria": [
+        "Develop and debug code in browser IDE",
+        "Track ML experiments and model performance",
+        "Manage code repositories and releases",
+        "Process and query document collections"
+      ],
+      "notes": "Complete development stack; scales well for small to medium teams"
+    },
+    {
+      "id": "platter.creative-professional",
+      "name": "Creative Professional",
+      "description": "Multimodal content generation platform designed for creators who need AI-powered tools for visual, audio, and video content production. Combines image generation, voice synthesis, and media processing capabilities with automation workflows to streamline creative processes. This platter addresses the needs of content creators, marketers, and designers who want to integrate AI generation tools into their creative workflows while maintaining professional quality and efficiency.",
+      "category": "specialized",
+      "target_audience": [
+        "content-creators",
+        "designers",
+        "marketers",
+        "artists"
+      ],
+      "combos": [
+        "combo.media-basic",
+        "combo.flow-builder"
+      ],
+      "additional_services": [
+        "uramaki.comfyui",
+        "temaki.whisper",
+        "temaki.coqui-tts",
+        "futomaki.minio",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 8,
+        "memory_gb": 16,
+        "storage_gb": 300,
+        "gpu_vram_gb": 12,
+        "gpu_required": true
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 350,
+        "hardware_onetime_usd": 2000,
+        "notes": "Requires powerful GPU for real-time generation"
+      },
+      "setup_time_minutes": 45,
+      "maintenance_level": "medium",
+      "creative_capabilities": [
+        "AI image generation (Stable Diffusion, FLUX)",
+        "Voice synthesis and cloning",
+        "Video and audio processing",
+        "Automated content workflows",
+        "Media format conversion"
+      ],
+      "use_cases": [
+        "Social media content creation",
+        "Marketing material generation",
+        "Podcast and video production",
+        "Digital art and design"
+      ],
+      "success_criteria": [
+        "Generate high-quality images from prompts",
+        "Convert speech to text and text to speech",
+        "Process and convert media files",
+        "Create automated content workflows"
+      ],
+      "warnings": [
+        "Requires powerful GPU for real-time generation",
+        "Model downloads can exceed 50GB",
+        "GPU memory requirements vary by model complexity"
+      ],
+      "notes": "Optimized for creative workflows; requires significant GPU resources"
+    },
+    {
+      "id": "platter.enterprise-starter",
+      "name": "Enterprise Starter",
+      "description": "Production-ready platform with essential compliance and security features for small to medium businesses entering the AI space. Provides authentication, secrets management, monitoring, and backup capabilities while maintaining reasonable complexity and cost. This platter bridges the gap between development and full enterprise deployments, offering professional-grade reliability without the overhead of comprehensive enterprise features.",
+      "category": "enterprise",
+      "target_audience": [
+        "small-business",
+        "startups",
+        "teams",
+        "professional-services"
+      ],
+      "combos": [
+        "combo.knowledge-rag",
+        "combo.security-core",
+        "combo.monitor-basic"
+      ],
+      "additional_services": [
+        "hosomaki.n8n",
+        "futomaki.minio",
+        "hosomaki.caddy",
+        "inari.grafana"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 8,
+        "memory_gb": 16,
+        "storage_gb": 200,
+        "gpu_vram_gb": 0,
+        "gpu_required": false,
+        "backup_storage_gb": 100
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 300,
+        "hardware_onetime_usd": 1500,
+        "notes": "Includes backup and redundancy costs"
+      },
+      "setup_time_minutes": 45,
+      "maintenance_level": "medium",
+      "enterprise_features": [
+        "Single sign-on authentication",
+        "Centralized secrets management",
+        "Comprehensive monitoring and alerting",
+        "Automated backup systems",
+        "Workflow automation capabilities"
+      ],
+      "compliance_features": {
+        "sso": {
+          "enabled": true,
+          "provider": "authentik"
+        },
+        "encryption": {
+          "at_rest": true,
+          "in_transit": true
+        },
+        "audit": {
+          "enabled": true,
+          "retention_days": 90
+        },
+        "backup": {
+          "automated": true,
+          "retention_policy": "30 days"
+        }
+      },
+      "use_cases": [
+        "Business AI implementations",
+        "Customer service automation",
+        "Internal knowledge management",
+        "Document processing workflows"
+      ],
+      "success_criteria": [
+        "Users can authenticate through SSO",
+        "All services monitored with alerts",
+        "Automated backups running successfully",
+        "Secrets managed centrally and securely"
+      ],
+      "notes": "Balanced approach to enterprise features; good stepping stone to full enterprise"
+    },
+    {
+      "id": "platter.enterprise-complete",
+      "name": "Enterprise Complete",
+      "description": "Full production stack with advanced compliance, high availability, and comprehensive security for regulated industries and large organizations. Includes HIPAA, GDPR, and SOX compliance features, advanced monitoring, centralized logging, and enterprise-grade security controls. This platter provides the complete infrastructure needed for mission-critical AI applications in regulated environments with strict data governance requirements.",
+      "category": "enterprise",
+      "target_audience": [
+        "enterprises",
+        "regulated-industries",
+        "government",
+        "healthcare"
+      ],
+      "combos": [
+        "combo.knowledge-rag",
+        "combo.security-core",
+        "combo.inference-fast"
+      ],
+      "additional_services": [
+        "hosomaki.n8n",
+        "futomaki.minio",
+        "hosomaki.caddy",
+        "inari.grafana",
+        "inari.prometheus",
+        "inari.loki",
+        "gunkanmaki.vault",
+        "chirashi.mlflow"
+      ],
+      "privacy_profile": "legal_privilege",
+      "resource_requirements": {
+        "cpu_cores": 16,
+        "memory_gb": 32,
+        "storage_gb": 500,
+        "gpu_vram_gb": 16,
+        "gpu_required": true,
+        "backup_storage_gb": 250
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 800,
+        "hardware_onetime_usd": 4000,
+        "notes": "Multi-instance deployment with redundancy"
+      },
+      "setup_time_minutes": 90,
+      "maintenance_level": "high",
+      "enterprise_features": [
+        "Advanced identity and access management",
+        "Comprehensive audit logging and retention",
+        "High-performance model serving",
+        "Centralized log aggregation",
+        "Enterprise secrets management",
+        "Automated failover and recovery"
+      ],
+      "compliance_features": {
+        "hipaa": {
+          "enabled": true,
+          "audit_retention_years": 7,
+          "encryption": "AES-256",
+          "baa_ready": true
+        },
+        "gdpr": {
+          "enabled": true,
+          "right_to_deletion": true,
+          "data_residency": "configurable",
+          "dpo_dashboard": true
+        },
+        "sox": {
+          "enabled": true,
+          "change_control": true,
+          "audit_immutability": true,
+          "separation_of_duties": true
+        }
+      },
+      "high_availability": {
+        "database_replication": true,
+        "service_redundancy": true,
+        "automated_failover": true,
+        "backup_sites": "recommended"
+      },
+      "sla_targets": {
+        "uptime": "99.9%",
+        "rto_hours": 1,
+        "rpo_minutes": 15,
+        "response_time_p99_ms": 200
+      },
+      "use_cases": [
+        "Regulated industry AI deployments",
+        "Enterprise knowledge management",
+        "High-performance model serving",
+        "Compliance-critical applications"
+      ],
+      "success_criteria": [
+        "All compliance features validated and active",
+        "High availability targets met",
+        "Audit logs properly retained and searchable",
+        "Model serving meets performance SLA"
+      ],
+      "warnings": [
+        "Requires dedicated infrastructure team",
+        "Complex compliance configuration needed",
+        "Significant ongoing maintenance overhead"
+      ],
+      "notes": "Full enterprise deployment; requires expert configuration and management"
+    },
+    {
+      "id": "platter.voice-first",
+      "name": "Voice First",
+      "description": "Voice-centric AI interaction platform optimized for speech-based applications and accessibility use cases. Combines speech-to-text, text-to-speech, and conversation management to create seamless voice interactions. This platter addresses the growing need for voice-enabled AI applications, from accessibility tools to IoT integrations and hands-free computing environments.",
+      "category": "specialized",
+      "target_audience": [
+        "accessibility-focused",
+        "iot-developers",
+        "voice-app-creators"
+      ],
+      "combos": [
+        "combo.chat-local",
+        "combo.flow-builder"
+      ],
+      "additional_services": [
+        "temaki.whisper",
+        "temaki.coqui-tts",
+        "futomaki.redis",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 6,
+        "memory_gb": 10,
+        "storage_gb": 80,
+        "gpu_vram_gb": 4,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 120,
+        "hardware_onetime_usd": 700,
+        "notes": "Optimized for voice processing efficiency"
+      },
+      "setup_time_minutes": 20,
+      "maintenance_level": "low",
+      "voice_features": [
+        "Real-time speech-to-text with Whisper",
+        "Multi-language support",
+        "Natural voice synthesis",
+        "Conversation state management",
+        "Low-latency voice processing"
+      ],
+      "use_cases": [
+        "Accessibility applications",
+        "Voice-controlled IoT systems",
+        "Hands-free computing environments",
+        "Interactive voice assistants"
+      ],
+      "success_criteria": [
+        "Real-time speech recognition working",
+        "Natural voice synthesis responding",
+        "End-to-end voice conversation functional",
+        "Acceptable latency for real-time interaction"
+      ],
+      "notes": "Specialized for voice applications; can run without GPU but benefits from one"
+    },
+    {
+      "id": "platter.research-lab",
+      "name": "Research Lab",
+      "description": "Academic and research environment designed for experimental AI research, paper reproduction, and collaborative scientific work. Provides comprehensive tools for data analysis, experiment tracking, model development, and research collaboration. This platter addresses the specific needs of academic researchers, graduate students, and R&D teams who need sophisticated AI infrastructure for experimental work and reproducible research.",
+      "category": "specialized",
+      "target_audience": [
+        "academics",
+        "researchers",
+        "graduate-students",
+        "r&d-teams"
+      ],
+      "combos": [
+        "combo.knowledge-rag",
+        "combo.dev-workspace",
+        "combo.analytics-starter",
+        "combo.monitor-basic"
+      ],
+      "additional_services": [
+        "chirashi.mlflow",
+        "futomaki.neo4j",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "open_research",
+      "resource_requirements": {
+        "cpu_cores": 8,
+        "memory_gb": 16,
+        "storage_gb": 300,
+        "gpu_vram_gb": 8,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 200,
+        "hardware_onetime_usd": 1200,
+        "notes": "Often eligible for academic discounts"
+      },
+      "setup_time_minutes": 35,
+      "maintenance_level": "medium",
+      "research_features": [
+        "Comprehensive experiment tracking",
+        "Collaborative development environment",
+        "Graph database for knowledge modeling",
+        "Advanced analytics and visualization",
+        "Reproducible research workflows"
+      ],
+      "use_cases": [
+        "Academic AI research",
+        "Paper reproduction and validation",
+        "Collaborative research projects",
+        "Graduate student training"
+      ],
+      "success_criteria": [
+        "Reproduce published research results",
+        "Track and compare experiment variations",
+        "Collaborate on shared research projects",
+        "Visualize complex research data and relationships"
+      ],
+      "notes": "Comprehensive research environment; designed for experimental and collaborative work"
+    },
+    {
+      "id": "platter.homelab-enthusiast",
+      "name": "Homelab Enthusiast",
+      "description": "Comprehensive self-hosting platform for technology enthusiasts who want to explore every aspect of modern AI infrastructure. Combines advanced services, monitoring, and automation to create a complete homelab experience. This platter is designed for hobbyists and professionals who enjoy experimenting with technology and want hands-on experience with enterprise-grade AI infrastructure in a home environment.",
+      "category": "showcase",
+      "target_audience": [
+        "homelab-enthusiasts",
+        "self-hosters",
+        "technology-hobbyists"
+      ],
+      "combos": [
+        "combo.knowledge-rag",
+        "combo.dev-workspace",
+        "combo.security-core",
+        "combo.monitor-basic",
+        "combo.media-basic"
+      ],
+      "additional_services": [
+        "chirashi.mlflow",
+        "sashimi.gitea",
+        "sashimi.homepage",
+        "futomaki.neo4j",
+        "uramaki.comfyui",
+        "hosomaki.caddy"
+      ],
+      "privacy_profile": "business_confidential",
+      "resource_requirements": {
+        "cpu_cores": 12,
+        "memory_gb": 24,
+        "storage_gb": 500,
+        "gpu_vram_gb": 12,
+        "gpu_required": false
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 400,
+        "hardware_onetime_usd": 2500,
+        "notes": "Designed for powerful homelab servers"
+      },
+      "setup_time_minutes": 60,
+      "maintenance_level": "high",
+      "homelab_features": [
+        "Complete AI development stack",
+        "Self-hosted version control",
+        "Personal dashboard and monitoring",
+        "Creative content generation",
+        "Advanced knowledge management",
+        "Comprehensive security stack"
+      ],
+      "use_cases": [
+        "Technology learning and experimentation",
+        "Personal AI assistant development",
+        "Content creation workflows",
+        "Self-hosted productivity suite"
+      ],
+      "success_criteria": [
+        "All major service categories functional",
+        "Unified dashboard showing system status",
+        "Personal AI assistant responding to queries",
+        "Content generation workflows operational"
+      ],
+      "notes": "Maximum functionality for enthusiasts; requires significant time investment"
+    },
+    {
+      "id": "platter.omakase",
+      "name": "Omakase",
+      "description": "The ultimate demonstration environment that includes every service in the Sushi Kitchen menu. This showcase platter is designed for testing, demonstrations, training, and comprehensive system validation. While not recommended for production use due to resource requirements and complexity, it provides the complete Sushi Kitchen experience and serves as a reference implementation for understanding service interactions across the entire platform.",
+      "category": "showcase",
+      "target_audience": [
+        "demonstrations",
+        "training",
+        "system-testing",
+        "comprehensive-evaluation"
+      ],
+      "combos": [
+        "combo.chat-local",
+        "combo.dev-workspace",
+        "combo.knowledge-rag",
+        "combo.flow-builder",
+        "combo.monitor-basic",
+        "combo.security-core",
+        "combo.storage-essentials",
+        "combo.inference-fast",
+        "combo.media-basic",
+        "combo.analytics-starter"
+      ],
+      "additional_services": [
+        "chirashi.mlflow",
+        "sashimi.gitea",
+        "sashimi.homepage",
+        "sashimi.docusaurus",
+        "futomaki.neo4j",
+        "uramaki.comfyui",
+        "temaki.whisper",
+        "temaki.coqui-tts",
+        "inari.loki",
+        "gunkanmaki.vault",
+        "otsumami.searxng"
+      ],
+      "privacy_profile": "open_research",
+      "resource_requirements": {
+        "cpu_cores": 24,
+        "memory_gb": 64,
+        "storage_gb": 1000,
+        "gpu_vram_gb": 24,
+        "gpu_required": true
+      },
+      "estimated_cost": {
+        "cloud_monthly_usd": 1200,
+        "hardware_onetime_usd": 8000,
+        "notes": "Requires server-class hardware or cluster deployment"
+      },
+      "setup_time_minutes": 120,
+      "maintenance_level": "expert",
+      "showcase_features": [
+        "Every service category represented",
+        "All major AI capabilities available",
+        "Complete observability stack",
+        "Full security and compliance features",
+        "Comprehensive development environment"
+      ],
+      "warnings": [
+        "Not recommended for production use",
+        "Intended for testing and demonstration only",
+        "Expect port conflicts without careful configuration",
+        "Requires significant expertise to manage",
+        "Resource consumption will be substantial"
+      ],
+      "use_cases": [
+        "Platform demonstrations",
+        "Comprehensive system testing",
+        "Training and education",
+        "Feature evaluation and comparison"
+      ],
+      "success_criteria": [
+        "All major service categories operational",
+        "No critical service failures or conflicts",
+        "Unified monitoring showing system health",
+        "Representative workflows from each category functional"
+      ],
+      "notes": "Complete showcase deployment; demonstrates full platform capabilities but requires expert management"
+    }
+  ],
+  "categories": {
+    "foundational": {
+      "name": "Foundation",
+      "description": "Essential starting points suitable for most users",
+      "icon": "foundation",
+      "color": "#28A745"
+    },
+    "specialized": {
+      "name": "Specialized",
+      "description": "Optimized for specific use cases and workflows",
+      "icon": "target",
+      "color": "#17A2B8"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "description": "Production-ready with compliance and security features",
+      "icon": "building",
+      "color": "#6610F2"
+    },
+    "showcase": {
+      "name": "Showcase",
+      "description": "Demonstration and comprehensive testing environments",
+      "icon": "star",
+      "color": "#FFC107"
+    }
+  },
+  "deployment_profiles": {
+    "minimal": {
+      "description": "Bare minimum for testing and learning",
+      "recommended_platters": [
+        "platter.hosomaki-core"
+      ],
+      "target_use_case": "Learning and basic testing"
+    },
+    "balanced": {
+      "description": "Good balance of features and resource requirements",
+      "recommended_platters": [
+        "platter.knowledge-worker",
+        "platter.developer-complete"
+      ],
+      "target_use_case": "Professional and development work"
+    },
+    "production": {
+      "description": "Enterprise-ready deployments",
+      "recommended_platters": [
+        "platter.enterprise-starter",
+        "platter.enterprise-complete"
+      ],
+      "target_use_case": "Business and production applications"
+    },
+    "specialized": {
+      "description": "Optimized for specific workflows",
+      "recommended_platters": [
+        "platter.creative-professional",
+        "platter.voice-first",
+        "platter.research-lab"
+      ],
+      "target_use_case": "Domain-specific applications"
+    }
+  },
+  "hardware_recommendations": {
+    "mini_pc": {
+      "suitable_platters": [
+        "platter.hosomaki-core",
+        "platter.voice-first"
+      ],
+      "specs": "Intel N100/N305, 16GB RAM, 512GB SSD",
+      "estimated_cost": "$300-500"
+    },
+    "desktop": {
+      "suitable_platters": [
+        "platter.knowledge-worker",
+        "platter.developer-complete"
+      ],
+      "specs": "Intel i5/AMD Ryzen 5, 32GB RAM, RTX 4060, 1TB NVMe",
+      "estimated_cost": "$800-1200"
+    },
+    "workstation": {
+      "suitable_platters": [
+        "platter.creative-professional",
+        "platter.research-lab",
+        "platter.homelab-enthusiast"
+      ],
+      "specs": "Intel i7/AMD Ryzen 7, 64GB RAM, RTX 4080, 2TB NVMe",
+      "estimated_cost": "$1500-3000"
+    },
+    "server": {
+      "suitable_platters": [
+        "platter.enterprise-starter",
+        "platter.enterprise-complete"
+      ],
+      "specs": "Dual Xeon/EPYC, 128GB RAM, RTX A6000, RAID storage",
+      "estimated_cost": "$3000-8000"
+    },
+    "cluster": {
+      "suitable_platters": [
+        "platter.omakase"
+      ],
+      "specs": "Multiple nodes, Kubernetes orchestration, distributed storage",
+      "estimated_cost": "$8000+"
+    }
+  }
+}

--- a/docs/manifest/web/api/examples/basic-rag-setup/docker-compose.json
+++ b/docs/manifest/web/api/examples/basic-rag-setup/docker-compose.json
@@ -1,0 +1,428 @@
+{
+  "version": "3.9",
+  "x-sushi-metadata": {
+    "labels": [
+      "sushi.kitchen.generated=true",
+      "sushi.kitchen.version=1.0.0",
+      "sushi.kitchen.generated-at=2025-09-16T23:15:00Z",
+      "sushi.kitchen.privacy-profile=open_research",
+      "sushi.kitchen.environment-template=development",
+      "sushi.kitchen.combo-ids=combo.chat-local",
+      "sushi.kitchen.service-count=4",
+      "sushi.kitchen.estimated-resources=cpu:4,memory:8gb,storage:50gb"
+    ]
+  },
+  "x-common-logging": {
+    "logging": {
+      "driver": "json-file",
+      "options": {
+        "max-size": "50m",
+        "max-file": "5",
+        "labels": "sushi.service,sushi.style"
+      }
+    }
+  },
+  "x-common-restart": {
+    "restart": "unless-stopped"
+  },
+  "x-development-security": {
+    "security_opt": [
+      "no-new-privileges:false"
+    ]
+  },
+  "services": {
+    "ollama": {
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "50m",
+          "max-file": "5",
+          "labels": "sushi.service,sushi.style"
+        }
+      },
+      "restart": "unless-stopped",
+      "security_opt": [
+        "no-new-privileges:false"
+      ],
+      "image": "ollama/ollama:latest",
+      "container_name": "sushi_ollama",
+      "platform": "linux/amd64",
+      "profiles": [
+        "hosomaki"
+      ],
+      "ports": [
+        "11434:11434"
+      ],
+      "volumes": [
+        "ollama_data:/root/.ollama"
+      ],
+      "environment": {
+        "OLLAMA_HOST": "0.0.0.0",
+        "OLLAMA_MODELS": "/root/.ollama/models",
+        "OLLAMA_KEEP_ALIVE": "5m",
+        "OLLAMA_DEBUG": "true",
+        "OLLAMA_VERBOSE": "true",
+        "OLLAMA_LOG_LEVEL": "debug"
+      },
+      "deploy": {
+        "resources": {
+          "reservations": {
+            "devices": [
+              {
+                "driver": "nvidia",
+                "count": "all",
+                "capabilities": [
+                  "gpu"
+                ]
+              }
+            ]
+          },
+          "limits": {
+            "cpus": "2.0",
+            "memory": "4G"
+          }
+        }
+      },
+      "networks": [
+        "sushi_net"
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:11434/api/tags"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "60s"
+      }
+    },
+    "anythingllm": {
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "50m",
+          "max-file": "5",
+          "labels": "sushi.service,sushi.style"
+        }
+      },
+      "restart": "unless-stopped",
+      "security_opt": [
+        "no-new-privileges:false"
+      ],
+      "image": "mintplexlabs/anythingllm:latest",
+      "container_name": "sushi_anythingllm",
+      "platform": "linux/amd64",
+      "profiles": [
+        "hosomaki"
+      ],
+      "ports": [
+        "3001:3001"
+      ],
+      "volumes": [
+        "anythingllm_storage:/app/server/storage",
+        "anythingllm_hotdir:/app/collector/hotdir"
+      ],
+      "environment": {
+        "STORAGE_DIR": "/app/server/storage",
+        "LLM_PROVIDER": "ollama",
+        "OLLAMA_BASE_PATH": "http://ollama:11434",
+        "EMBEDDING_ENGINE": "ollama",
+        "EMBEDDING_BASE_PATH": "http://ollama:11434",
+        "VECTOR_DB": "qdrant",
+        "QDRANT_ENDPOINT": "http://qdrant:6333",
+        "DATABASE_CONNECTION_STRING": "postgresql://anythingllm:${POSTGRES_PASSWORD}@postgresql:5432/anythingllm",
+        "JWT_SECRET": "${ANYTHINGLLM_JWT_SECRET}"
+      },
+      "depends_on": {
+        "ollama": {
+          "condition": "service_healthy"
+        },
+        "qdrant": {
+          "condition": "service_healthy"
+        },
+        "postgresql": {
+          "condition": "service_healthy"
+        }
+      },
+      "deploy": {
+        "resources": {
+          "limits": {
+            "cpus": "1.0",
+            "memory": "2G"
+          }
+        }
+      },
+      "networks": [
+        "sushi_net"
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:3001/api/system"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "90s"
+      }
+    },
+    "qdrant": {
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "50m",
+          "max-file": "5",
+          "labels": "sushi.service,sushi.style"
+        }
+      },
+      "restart": "unless-stopped",
+      "security_opt": [
+        "no-new-privileges:false"
+      ],
+      "image": "qdrant/qdrant:latest",
+      "container_name": "sushi_qdrant",
+      "platform": "linux/amd64",
+      "profiles": [
+        "futomaki"
+      ],
+      "ports": [
+        "6333:6333",
+        "6334:6334"
+      ],
+      "volumes": [
+        "qdrant_storage:/qdrant/storage"
+      ],
+      "environment": {
+        "QDRANT__SERVICE__HTTP_PORT": "6333",
+        "QDRANT__SERVICE__GRPC_PORT": "6334",
+        "QDRANT__LOG_LEVEL": "debug",
+        "QDRANT__SERVICE__ENABLE_CORS": "true",
+        "QDRANT__TELEMETRY_DISABLED": "true",
+        "QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS": "2"
+      },
+      "deploy": {
+        "resources": {
+          "limits": {
+            "cpus": "1.0",
+            "memory": "2G"
+          }
+        }
+      },
+      "networks": [
+        "sushi_net"
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:6333/health"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "30s"
+      }
+    },
+    "postgresql": {
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "50m",
+          "max-file": "5",
+          "labels": "sushi.service,sushi.style"
+        }
+      },
+      "restart": "unless-stopped",
+      "security_opt": [
+        "no-new-privileges:false"
+      ],
+      "image": "postgres:15-alpine",
+      "container_name": "sushi_postgresql",
+      "platform": "linux/amd64",
+      "profiles": [
+        "futomaki"
+      ],
+      "ports": [
+        "5432:5432"
+      ],
+      "volumes": [
+        "postgresql_data:/var/lib/postgresql/data"
+      ],
+      "environment": {
+        "POSTGRES_DB": "anythingllm",
+        "POSTGRES_USER": "anythingllm",
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+        "PGDATA": "/var/lib/postgresql/data/pgdata",
+        "POSTGRES_LOG_STATEMENT": "all",
+        "POSTGRES_LOG_DURATION": "true",
+        "POSTGRES_LOG_CHECKPOINTS": "true",
+        "POSTGRES_LOG_CONNECTIONS": "true",
+        "POSTGRES_LOG_DISCONNECTIONS": "true"
+      },
+      "deploy": {
+        "resources": {
+          "limits": {
+            "cpus": "1.0",
+            "memory": "1G"
+          }
+        }
+      },
+      "networks": [
+        "sushi_net"
+      ],
+      "healthcheck": {
+        "test": [
+          "CMD-SHELL",
+          "pg_isready -U anythingllm -d anythingllm"
+        ],
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 3,
+        "start_period": "30s"
+      }
+    }
+  },
+  "networks": {
+    "sushi_net": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.20.0.0/16",
+            "gateway": "172.20.0.1",
+            "ip_range": "172.20.1.0/24"
+          }
+        ]
+      },
+      "labels": [
+        "sushi.kitchen.network.profile=open_research",
+        "sushi.kitchen.network.isolation=minimal",
+        "sushi.kitchen.network.purpose=development"
+      ]
+    }
+  },
+  "volumes": {
+    "ollama_data": {
+      "driver": "local",
+      "labels": [
+        "sushi.kitchen.volume.service=ollama",
+        "sushi.kitchen.volume.backup_priority=medium",
+        "sushi.kitchen.volume.content=models"
+      ]
+    },
+    "anythingllm_storage": {
+      "driver": "local",
+      "labels": [
+        "sushi.kitchen.volume.service=anythingllm",
+        "sushi.kitchen.volume.backup_priority=high",
+        "sushi.kitchen.volume.content=application_data"
+      ]
+    },
+    "anythingllm_hotdir": {
+      "driver": "local",
+      "labels": [
+        "sushi.kitchen.volume.service=anythingllm",
+        "sushi.kitchen.volume.backup_priority=high",
+        "sushi.kitchen.volume.content=document_uploads"
+      ]
+    },
+    "qdrant_storage": {
+      "driver": "local",
+      "labels": [
+        "sushi.kitchen.volume.service=qdrant",
+        "sushi.kitchen.volume.backup_priority=critical",
+        "sushi.kitchen.volume.content=vector_embeddings"
+      ]
+    },
+    "postgresql_data": {
+      "driver": "local",
+      "labels": [
+        "sushi.kitchen.volume.service=postgresql",
+        "sushi.kitchen.volume.backup_priority=critical",
+        "sushi.kitchen.volume.content=database"
+      ]
+    }
+  },
+  "x-sushi-deployment-info": {
+    "generation_timestamp": "2025-09-16T23:15:00Z",
+    "selected_combos": [
+      {
+        "id": "combo.chat-local",
+        "name": "Local Chat",
+        "services": [
+          "hosomaki.ollama",
+          "hosomaki.anythingllm"
+        ]
+      }
+    ],
+    "privacy_profile": "open_research",
+    "environment_template": "development",
+    "estimated_resources": {
+      "total_cpu_cores": 4,
+      "total_memory_gb": 8,
+      "total_storage_gb": 50,
+      "gpu_required": false,
+      "gpu_memory_gb": 0
+    },
+    "service_dependencies": {
+      "hosomaki.anythingllm": {
+        "requires": [
+          "hosomaki.ollama",
+          "futomaki.qdrant",
+          "futomaki.postgresql"
+        ]
+      },
+      "hosomaki.ollama": [],
+      "futomaki.qdrant": [],
+      "futomaki.postgresql": []
+    },
+    "capability_providers": {
+      "local_llm_inference": "hosomaki.ollama",
+      "vector_storage": "futomaki.qdrant",
+      "relational_storage": "futomaki.postgresql"
+    },
+    "health_check_endpoints": {
+      "ollama": "http://localhost:11434/api/tags",
+      "anythingllm": "http://localhost:3001/api/system",
+      "qdrant": "http://localhost:6333/health",
+      "postgresql": "pg_isready check"
+    },
+    "external_ports": {
+      "web_interface": "http://localhost:3001",
+      "ollama_api": "http://localhost:11434",
+      "qdrant_api": "http://localhost:6333",
+      "postgresql_db": "postgresql://localhost:5432"
+    },
+    "backup_priorities": {
+      "critical": [
+        "postgresql_data",
+        "qdrant_storage"
+      ],
+      "high": [
+        "anythingllm_storage",
+        "anythingllm_hotdir"
+      ],
+      "medium": [
+        "ollama_data"
+      ]
+    },
+    "validation_commands": {
+      "service_health": "docker-compose ps",
+      "ollama_models": "docker-compose exec ollama ollama list",
+      "qdrant_health": "curl -f http://localhost:6333/health",
+      "anythingllm_api": "curl -f http://localhost:3001/api/system",
+      "database_connection": "docker-compose exec postgresql pg_isready -U anythingllm"
+    }
+  }
+}

--- a/docs/manifest/web/api/templates/environment-configs/development.json
+++ b/docs/manifest/web/api/templates/environment-configs/development.json
@@ -1,0 +1,243 @@
+{
+  "global_environment": {
+    "LOG_LEVEL": "DEBUG",
+    "DEBUG_MODE": "true",
+    "VERBOSE_LOGGING": "true",
+    "SHOW_ERROR_DETAILS": "true",
+    "ENABLE_STACK_TRACES": "true",
+    "DEBUG_PRINT_QUERIES": "true",
+    "LOG_FORMAT": "development",
+    "LOG_OUTPUT": "console",
+    "LOG_TIMESTAMP_FORMAT": "HH:mm:ss.SSS",
+    "SSL_VERIFY": "false",
+    "TLS_SKIP_VERIFY": "true",
+    "HTTPS_ONLY": "false",
+    "ALLOW_HTTP": "true",
+    "CSRF_PROTECTION": "disabled",
+    "CORS_ALLOW_ALL": "true",
+    "AUTH_REQUIRED": "false",
+    "SKIP_AUTH_FOR_DEVELOPMENT": "true",
+    "DEVELOPMENT_MODE": "true",
+    "ENABLE_CACHING": "false",
+    "CACHE_TTL": "0",
+    "DISABLE_REDIS_CACHE": "true",
+    "REQUEST_TIMEOUT": "30s",
+    "CONNECTION_TIMEOUT": "10s",
+    "STARTUP_TIMEOUT": "60s",
+    "ENABLE_HOT_RELOAD": "true",
+    "AUTO_RESTART": "true",
+    "WATCH_FILES": "true",
+    "DATA_RETENTION_DAYS": "7",
+    "AUTO_CLEANUP_ENABLED": "true",
+    "DEVELOPMENT_DATA_RESET": "true",
+    "BACKUP_ENABLED": "false",
+    "BACKUP_FREQUENCY": "none",
+    "LOAD_SAMPLE_DATA": "true",
+    "ENABLE_DATA_FIXTURES": "true",
+    "DEVELOPMENT_SEED_DATA": "true",
+    "MEMORY_LIMIT": "2g",
+    "CPU_LIMIT": "2.0",
+    "WORKER_COUNT": "2",
+    "MAX_CONNECTIONS": "50",
+    "POOL_SIZE": "5",
+    "HEALTH_CHECK_INTERVAL": "15s",
+    "HEALTH_CHECK_TIMEOUT": "5s",
+    "STARTUP_GRACE_PERIOD": "120s"
+  },
+  "service_overrides": {
+    "ai_services": {
+      "hosomaki.ollama": {
+        "OLLAMA_DEBUG": "true",
+        "OLLAMA_VERBOSE": "true",
+        "OLLAMA_KEEP_ALIVE": "5m",
+        "OLLAMA_MAX_LOADED_MODELS": "2",
+        "OLLAMA_LOAD_TIMEOUT": "30s",
+        "OLLAMA_LOG_LEVEL": "debug"
+      },
+      "hosomaki.litellm": {
+        "LITELLM_LOG": "debug",
+        "LITELLM_DEBUG_MODE": "true",
+        "LITELLM_DETAILED_LOGGER": "true",
+        "LITELLM_DROP_PARAMS": "false",
+        "LITELLM_REQUEST_TIMEOUT": "60"
+      },
+      "hosomaki.vllm": {
+        "VLLM_LOGGING_LEVEL": "debug",
+        "VLLM_LOG_STATS": "true",
+        "VLLM_ENABLE_METRICS": "true",
+        "VLLM_DISABLE_LOG_REQUESTS": "false"
+      }
+    },
+    "database_services": {
+      "futomaki.postgresql": {
+        "POSTGRES_LOG_STATEMENT": "all",
+        "POSTGRES_LOG_DURATION": "true",
+        "POSTGRES_LOG_CHECKPOINTS": "true",
+        "POSTGRES_LOG_CONNECTIONS": "true",
+        "POSTGRES_LOG_DISCONNECTIONS": "true",
+        "POSTGRES_SHARED_PRELOAD_LIBRARIES": "pg_stat_statements"
+      },
+      "futomaki.qdrant": {
+        "QDRANT__LOG_LEVEL": "debug",
+        "QDRANT__SERVICE__ENABLE_CORS": "true",
+        "QDRANT__TELEMETRY_DISABLED": "true",
+        "QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS": "2"
+      },
+      "futomaki.redis": {
+        "REDIS_LOG_LEVEL": "debug",
+        "REDIS_SAVE": "",
+        "REDIS_APPENDONLY": "no",
+        "REDIS_MAXMEMORY_POLICY": "allkeys-lru"
+      }
+    },
+    "web_services": {
+      "hosomaki.caddy": {
+        "CADDY_DEBUG": "true",
+        "CADDY_LOG_LEVEL": "debug",
+        "CADDY_ADMIN_LISTEN": "0.0.0.0:2019",
+        "CADDY_ACME_DISABLE": "true"
+      },
+      "hosomaki.n8n": {
+        "N8N_LOG_LEVEL": "debug",
+        "N8N_LOG_OUTPUT": "console",
+        "N8N_DIAGNOSTICS_ENABLED": "true",
+        "N8N_PERSONALIZATION_ENABLED": "false",
+        "N8N_VERSION_NOTIFICATIONS_ENABLED": "false",
+        "N8N_TEMPLATES_ENABLED": "false"
+      }
+    },
+    "monitoring_services": {
+      "inari.prometheus": {
+        "PROMETHEUS_LOG_LEVEL": "debug",
+        "PROMETHEUS_ENABLE_LIFECYCLE": "true",
+        "PROMETHEUS_STORAGE_TSDB_RETENTION_TIME": "7d",
+        "PROMETHEUS_WEB_ENABLE_ADMIN_API": "true"
+      },
+      "inari.grafana": {
+        "GF_LOG_LEVEL": "debug",
+        "GF_ENABLE_GZIP": "true",
+        "GF_USERS_ALLOW_SIGN_UP": "true",
+        "GF_AUTH_ANONYMOUS_ENABLED": "true",
+        "GF_AUTH_ANONYMOUS_ORG_ROLE": "Editor",
+        "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH": "/var/lib/grafana/dashboards/dev-overview.json"
+      }
+    }
+  },
+  "development_tools": {
+    "database_tools": {
+      "enable_pgadmin": true,
+      "enable_redis_commander": true,
+      "enable_qdrant_dashboard": true
+    },
+    "api_tools": {
+      "enable_swagger_ui": true,
+      "enable_postman_collection": true,
+      "enable_curl_examples": true
+    },
+    "monitoring_tools": {
+      "enable_dev_dashboard": true,
+      "enable_log_viewer": true,
+      "enable_metrics_explorer": true
+    },
+    "automation_tools": {
+      "enable_auto_migration": true,
+      "enable_test_data_seeding": true,
+      "enable_service_discovery": true
+    }
+  },
+  "docker_integration": {
+    "development_volumes": {
+      "enable_source_mounts": true,
+      "enable_config_mounts": true,
+      "enable_log_mounts": true
+    },
+    "port_strategy": {
+      "expose_all_services": true,
+      "use_standard_ports": true,
+      "enable_port_forwarding": true
+    },
+    "container_settings": {
+      "restart_policy": "no",
+      "enable_init": true,
+      "enable_interactive": true
+    }
+  },
+  "development_validation": {
+    "health_checks": {
+      "interval": "15s",
+      "timeout": "5s",
+      "retries": 2,
+      "start_period": "30s"
+    },
+    "success_criteria": {
+      "all_services_responding": "All services respond to health checks within 30 seconds",
+      "logs_accessible": "All service logs are visible and updating in real-time",
+      "apis_documented": "All API endpoints are accessible and documented",
+      "debugging_enabled": "Debug features and verbose logging are working",
+      "hot_reload_functional": "Code changes trigger automatic service updates"
+    },
+    "troubleshooting": {
+      "enable_debug_endpoints": true,
+      "enable_metrics_endpoints": true,
+      "enable_profiling": true,
+      "enable_tracing": true
+    }
+  },
+  "environment_evolution": {
+    "migration_paths": {
+      "to_production": {
+        "description": "Move from development to production configuration",
+        "key_changes": [
+          "Enable security features and authentication",
+          "Optimize performance settings and disable debugging",
+          "Enable backup and monitoring systems",
+          "Configure proper SSL certificates and encryption",
+          "Implement proper resource limits and scaling"
+        ]
+      },
+      "to_staging": {
+        "description": "Create staging environment for testing",
+        "key_changes": [
+          "Production-like security but with development debugging",
+          "Test data that mirrors production patterns",
+          "Full monitoring and alerting without notifications",
+          "Performance testing with realistic load simulation"
+        ]
+      }
+    },
+    "maintenance_procedures": {
+      "daily_tasks": [
+        "Clear development logs and temporary files",
+        "Reset test databases to clean state",
+        "Update development dependencies and images",
+        "Verify all debugging features are working"
+      ],
+      "weekly_tasks": [
+        "Review and update development configurations",
+        "Test migration procedures to other environments",
+        "Update development documentation and examples",
+        "Clean up unused development resources and data"
+      ]
+    }
+  },
+  "development_best_practices": {
+    "coding_guidelines": {
+      "configuration_management": "Use environment variables for all configurable values",
+      "service_dependencies": "Design services to gracefully handle dependency failures",
+      "logging_practices": "Include request IDs and correlation IDs in all log messages",
+      "error_handling": "Provide detailed error messages with debugging context"
+    },
+    "testing_guidelines": {
+      "unit_testing": "Run unit tests automatically on code changes",
+      "integration_testing": "Test service interactions with realistic data",
+      "end_to_end_testing": "Validate complete workflows from user perspective",
+      "performance_testing": "Monitor resource usage and response times"
+    },
+    "security_guidelines": {
+      "secret_management": "Use development-specific secrets, never production secrets",
+      "data_handling": "Use synthetic data that resembles production but isn't sensitive",
+      "access_controls": "Implement basic access controls even in development",
+      "vulnerability_scanning": "Regularly scan development images for vulnerabilities"
+    }
+  }
+}

--- a/docs/manifest/web/api/templates/environment-configs/production.json
+++ b/docs/manifest/web/api/templates/environment-configs/production.json
@@ -1,0 +1,338 @@
+{
+  "global_environment": {
+    "LOG_LEVEL": "INFO",
+    "DEBUG_MODE": "false",
+    "VERBOSE_LOGGING": "false",
+    "LOG_FORMAT": "json",
+    "LOG_OUTPUT": "file",
+    "LOG_TIMESTAMP_FORMAT": "ISO8601",
+    "SHOW_ERROR_DETAILS": "false",
+    "ENABLE_STACK_TRACES": "false",
+    "LOG_CORRELATION_ID": "true",
+    "LOG_MAX_SIZE": "100MB",
+    "LOG_MAX_FILES": "10",
+    "LOG_RETENTION_DAYS": "30",
+    "LOG_COMPRESSION": "true",
+    "SSL_VERIFY": "true",
+    "TLS_SKIP_VERIFY": "false",
+    "HTTPS_ONLY": "true",
+    "TLS_MIN_VERSION": "1.2",
+    "ALLOW_HTTP": "false",
+    "CSRF_PROTECTION": "enabled",
+    "CORS_ALLOW_ALL": "false",
+    "SECURITY_HEADERS_ENABLED": "true",
+    "AUTH_REQUIRED": "true",
+    "SKIP_AUTH_FOR_DEVELOPMENT": "false",
+    "PRODUCTION_MODE": "true",
+    "SESSION_SECURE": "true",
+    "SESSION_HTTPONLY": "true",
+    "RATE_LIMITING_ENABLED": "true",
+    "REQUEST_SIZE_LIMIT": "10MB",
+    "UPLOAD_SIZE_LIMIT": "100MB",
+    "ENABLE_WAF": "true",
+    "ENABLE_CACHING": "true",
+    "CACHE_TTL": "3600",
+    "REDIS_CACHE_ENABLED": "true",
+    "CACHE_COMPRESSION": "true",
+    "REQUEST_TIMEOUT": "60s",
+    "CONNECTION_TIMEOUT": "30s",
+    "STARTUP_TIMEOUT": "300s",
+    "SHUTDOWN_TIMEOUT": "30s",
+    "ENABLE_HOT_RELOAD": "false",
+    "AUTO_RESTART": "false",
+    "WATCH_FILES": "false",
+    "CONNECTION_POOL_SIZE": "20",
+    "CONNECTION_POOL_MAX": "50",
+    "CONNECTION_POOL_TIMEOUT": "10s",
+    "KEEP_ALIVE_TIMEOUT": "75s",
+    "METRICS_ENABLED": "true",
+    "PROMETHEUS_METRICS": "true",
+    "HEALTH_CHECKS_ENABLED": "true",
+    "TRACING_ENABLED": "true",
+    "PROFILING_ENABLED": "false",
+    "ALERTING_ENABLED": "true",
+    "ALERT_WEBHOOK_URL": "${ALERT_WEBHOOK_URL}",
+    "SLACK_ALERTS_ENABLED": "true",
+    "EMAIL_ALERTS_ENABLED": "true",
+    "APM_ENABLED": "true",
+    "ERROR_TRACKING_ENABLED": "true",
+    "PERFORMANCE_MONITORING": "true",
+    "UPTIME_MONITORING": "true",
+    "DATA_RETENTION_DAYS": "365",
+    "AUTO_CLEANUP_ENABLED": "true",
+    "PRODUCTION_DATA_PROTECTION": "true",
+    "BACKUP_ENABLED": "true",
+    "BACKUP_FREQUENCY": "daily",
+    "BACKUP_RETENTION_DAYS": "90",
+    "BACKUP_ENCRYPTION": "true",
+    "OFFSITE_BACKUP_ENABLED": "true",
+    "DATA_VALIDATION_ENABLED": "true",
+    "CHECKSUM_VALIDATION": "true",
+    "CORRUPTION_DETECTION": "true",
+    "MEMORY_LIMIT": "8g",
+    "CPU_LIMIT": "4.0",
+    "STORAGE_LIMIT": "500g",
+    "WORKER_COUNT": "8",
+    "MAX_CONNECTIONS": "1000",
+    "POOL_SIZE": "50",
+    "QUEUE_SIZE": "500",
+    "HEALTH_CHECK_INTERVAL": "30s",
+    "HEALTH_CHECK_TIMEOUT": "10s",
+    "STARTUP_GRACE_PERIOD": "180s",
+    "LIVENESS_PROBE_ENABLED": "true",
+    "READINESS_PROBE_ENABLED": "true"
+  },
+  "service_overrides": {
+    "ai_services": {
+      "hosomaki.ollama": {
+        "OLLAMA_DEBUG": "false",
+        "OLLAMA_VERBOSE": "false",
+        "OLLAMA_KEEP_ALIVE": "24h",
+        "OLLAMA_MAX_LOADED_MODELS": "5",
+        "OLLAMA_LOAD_TIMEOUT": "300s",
+        "OLLAMA_LOG_LEVEL": "info",
+        "OLLAMA_NUM_PARALLEL": "4",
+        "OLLAMA_MAX_QUEUE": "100"
+      },
+      "hosomaki.litellm": {
+        "LITELLM_LOG": "info",
+        "LITELLM_DEBUG_MODE": "false",
+        "LITELLM_DETAILED_LOGGER": "false",
+        "LITELLM_DROP_PARAMS": "true",
+        "LITELLM_REQUEST_TIMEOUT": "120",
+        "LITELLM_MAX_PARALLEL_REQUESTS": "100",
+        "LITELLM_CACHE_ENABLED": "true"
+      },
+      "hosomaki.vllm": {
+        "VLLM_LOGGING_LEVEL": "info",
+        "VLLM_LOG_STATS": "true",
+        "VLLM_ENABLE_METRICS": "true",
+        "VLLM_DISABLE_LOG_REQUESTS": "true",
+        "VLLM_GPU_MEMORY_UTILIZATION": "0.9",
+        "VLLM_MAX_NUM_SEQS": "256",
+        "VLLM_MAX_MODEL_LEN": "4096"
+      }
+    },
+    "database_services": {
+      "futomaki.postgresql": {
+        "POSTGRES_LOG_STATEMENT": "mod",
+        "POSTGRES_LOG_DURATION": "true",
+        "POSTGRES_LOG_CHECKPOINTS": "false",
+        "POSTGRES_LOG_CONNECTIONS": "false",
+        "POSTGRES_LOG_DISCONNECTIONS": "false",
+        "POSTGRES_SHARED_PRELOAD_LIBRARIES": "pg_stat_statements",
+        "POSTGRES_MAX_CONNECTIONS": "200",
+        "POSTGRES_SHARED_BUFFERS": "2GB",
+        "POSTGRES_EFFECTIVE_CACHE_SIZE": "6GB",
+        "POSTGRES_CHECKPOINT_COMPLETION_TARGET": "0.9"
+      },
+      "futomaki.qdrant": {
+        "QDRANT__LOG_LEVEL": "info",
+        "QDRANT__SERVICE__ENABLE_CORS": "false",
+        "QDRANT__TELEMETRY_DISABLED": "true",
+        "QDRANT__STORAGE__PERFORMANCE__MAX_SEARCH_THREADS": "8",
+        "QDRANT__SERVICE__MAX_REQUEST_SIZE_MB": "100",
+        "QDRANT__STORAGE__OPTIMIZERS_ENABLED": "true",
+        "QDRANT__STORAGE__WRITE_CONSISTENCY_FACTOR": "1"
+      },
+      "futomaki.redis": {
+        "REDIS_LOG_LEVEL": "notice",
+        "REDIS_SAVE": "900 1 300 10 60 10000",
+        "REDIS_APPENDONLY": "yes",
+        "REDIS_APPENDFSYNC": "everysec",
+        "REDIS_MAXMEMORY_POLICY": "allkeys-lru",
+        "REDIS_MAXMEMORY": "4gb",
+        "REDIS_TCP_KEEPALIVE": "300",
+        "REDIS_TIMEOUT": "0"
+      }
+    },
+    "web_services": {
+      "hosomaki.caddy": {
+        "CADDY_DEBUG": "false",
+        "CADDY_LOG_LEVEL": "info",
+        "CADDY_ADMIN_LISTEN": "127.0.0.1:2019",
+        "CADDY_ACME_ENABLE": "true",
+        "CADDY_HTTP_PORT": "80",
+        "CADDY_HTTPS_PORT": "443",
+        "CADDY_GRACE_PERIOD": "30s",
+        "CADDY_MAX_HEADER_SIZE": "16KB"
+      },
+      "hosomaki.n8n": {
+        "N8N_LOG_LEVEL": "info",
+        "N8N_LOG_OUTPUT": "file",
+        "N8N_DIAGNOSTICS_ENABLED": "false",
+        "N8N_PERSONALIZATION_ENABLED": "true",
+        "N8N_VERSION_NOTIFICATIONS_ENABLED": "false",
+        "N8N_TEMPLATES_ENABLED": "true",
+        "N8N_EXECUTIONS_DATA_MAX_AGE": "336",
+        "N8N_EXECUTIONS_DATA_PRUNE": "true",
+        "N8N_METRICS": "true"
+      }
+    },
+    "monitoring_services": {
+      "inari.prometheus": {
+        "PROMETHEUS_LOG_LEVEL": "info",
+        "PROMETHEUS_ENABLE_LIFECYCLE": "false",
+        "PROMETHEUS_STORAGE_TSDB_RETENTION_TIME": "90d",
+        "PROMETHEUS_STORAGE_TSDB_RETENTION_SIZE": "50GB",
+        "PROMETHEUS_WEB_ENABLE_ADMIN_API": "false",
+        "PROMETHEUS_QUERY_MAX_CONCURRENCY": "20",
+        "PROMETHEUS_QUERY_TIMEOUT": "2m"
+      },
+      "inari.grafana": {
+        "GF_LOG_LEVEL": "info",
+        "GF_ENABLE_GZIP": "true",
+        "GF_USERS_ALLOW_SIGN_UP": "false",
+        "GF_AUTH_ANONYMOUS_ENABLED": "false",
+        "GF_SECURITY_ADMIN_PASSWORD": "${GRAFANA_ADMIN_PASSWORD}",
+        "GF_SECURITY_SECRET_KEY": "${GRAFANA_SECRET_KEY}",
+        "GF_SESSION_LIFE_TIME": "86400",
+        "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH": "/var/lib/grafana/dashboards/production-overview.json",
+        "GF_ALERTING_ENABLED": "true",
+        "GF_SMTP_ENABLED": "true"
+      }
+    }
+  },
+  "security_hardening": {
+    "container_security": {
+      "run_as_non_root": true,
+      "read_only_root_filesystem": true,
+      "no_new_privileges": true,
+      "drop_capabilities": [
+        "ALL"
+      ],
+      "add_capabilities": [
+        "CHOWN",
+        "SETGID",
+        "SETUID"
+      ]
+    },
+    "network_security": {
+      "enable_network_policies": true,
+      "restrict_egress_traffic": true,
+      "enable_service_mesh": true,
+      "require_tls_everywhere": true
+    },
+    "secrets_management": {
+      "use_external_secrets": true,
+      "rotate_secrets_regularly": true,
+      "encrypt_secrets_at_rest": true,
+      "audit_secret_access": true
+    }
+  },
+  "production_monitoring": {
+    "system_health": {
+      "cpu_utilization_threshold": 80,
+      "memory_utilization_threshold": 85,
+      "disk_utilization_threshold": 90,
+      "network_error_threshold": 1
+    },
+    "application_performance": {
+      "response_time_threshold": "2s",
+      "error_rate_threshold": 1,
+      "throughput_threshold": 100,
+      "availability_threshold": 99.9
+    },
+    "business_metrics": {
+      "active_users_threshold": 10,
+      "conversion_rate_threshold": 5,
+      "revenue_impact_monitoring": true,
+      "customer_satisfaction_tracking": true
+    },
+    "infrastructure_monitoring": {
+      "database_performance": true,
+      "cache_hit_ratio": true,
+      "queue_depth_monitoring": true,
+      "external_dependency_monitoring": true
+    }
+  },
+  "backup_and_recovery": {
+    "backup_configuration": {
+      "full_backup_schedule": "daily",
+      "incremental_backup_schedule": "hourly",
+      "backup_retention_policy": "3-2-1",
+      "backup_encryption": "AES-256",
+      "backup_compression": "true"
+    },
+    "disaster_recovery": {
+      "recovery_time_objective": "4h",
+      "recovery_point_objective": "1h",
+      "automated_failover": true,
+      "manual_failover_procedures": true,
+      "disaster_recovery_testing": "monthly"
+    },
+    "data_integrity": {
+      "checksum_verification": true,
+      "restore_testing": "weekly",
+      "data_corruption_detection": true,
+      "integrity_alerting": true
+    }
+  },
+  "scaling_configuration": {
+    "horizontal_scaling": {
+      "enable_auto_scaling": true,
+      "min_replicas": 2,
+      "max_replicas": 10,
+      "target_cpu_utilization": 70,
+      "target_memory_utilization": 80,
+      "scale_up_cooldown": "5m",
+      "scale_down_cooldown": "10m"
+    },
+    "vertical_scaling": {
+      "enable_vpa": true,
+      "cpu_request_multiplier": 1.5,
+      "memory_request_multiplier": 1.2,
+      "resource_limit_enforcement": true
+    },
+    "load_balancing": {
+      "load_balancing_algorithm": "round_robin",
+      "health_check_based_routing": true,
+      "circuit_breaker_enabled": true,
+      "retry_policy": "exponential_backoff",
+      "timeout_policy": "adaptive"
+    }
+  },
+  "deployment_strategy": {
+    "blue_green_deployment": {
+      "enable_blue_green": true,
+      "health_check_duration": "10m",
+      "automatic_rollback": true,
+      "traffic_shift_duration": "30m"
+    },
+    "canary_deployment": {
+      "enable_canary": true,
+      "canary_traffic_percentage": 10,
+      "canary_duration": "2h",
+      "success_criteria": {
+        "error_rate_threshold": 0.5,
+        "response_time_threshold": "1s"
+      }
+    },
+    "maintenance_procedures": {
+      "scheduled_maintenance_window": "Sunday 02:00-04:00 UTC",
+      "emergency_maintenance_procedures": true,
+      "change_approval_required": true,
+      "rollback_procedures_tested": true
+    }
+  },
+  "cost_optimization": {
+    "resource_optimization": {
+      "right_sizing_enabled": true,
+      "reserved_instance_planning": true,
+      "spot_instance_utilization": false,
+      "resource_tagging": true
+    },
+    "storage_optimization": {
+      "storage_tiering": true,
+      "data_compression": true,
+      "lifecycle_policies": true,
+      "unused_resource_cleanup": true
+    },
+    "cost_monitoring": {
+      "cost_budgets_enabled": true,
+      "cost_anomaly_detection": true,
+      "resource_utilization_tracking": true,
+      "cost_optimization_recommendations": true
+    }
+  }
+}

--- a/docs/manifest/web/api/templates/network-profiles/business-confidential.json
+++ b/docs/manifest/web/api/templates/network-profiles/business-confidential.json
@@ -1,0 +1,358 @@
+{
+  "networks": {
+    "sushi_frontend": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.21.0.0/24",
+            "gateway": "172.21.0.1",
+            "ip_range": "172.21.0.0/26"
+          }
+        ]
+      },
+      "labels": [
+        "sushi.kitchen.network.profile=business_confidential",
+        "sushi.kitchen.network.tier=frontend",
+        "sushi.kitchen.network.access=external",
+        "sushi.kitchen.network.purpose=user_interface"
+      ]
+    },
+    "sushi_backend": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.22.0.0/24",
+            "gateway": "172.22.0.1",
+            "ip_range": "172.22.0.0/26"
+          }
+        ]
+      },
+      "internal": false,
+      "labels": [
+        "sushi.kitchen.network.profile=business_confidential",
+        "sushi.kitchen.network.tier=backend",
+        "sushi.kitchen.network.access=internal",
+        "sushi.kitchen.network.purpose=processing"
+      ]
+    },
+    "sushi_data": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.23.0.0/24",
+            "gateway": "172.23.0.1",
+            "ip_range": "172.23.0.0/26"
+          }
+        ]
+      },
+      "internal": true,
+      "labels": [
+        "sushi.kitchen.network.profile=business_confidential",
+        "sushi.kitchen.network.tier=data",
+        "sushi.kitchen.network.access=none",
+        "sushi.kitchen.network.purpose=storage"
+      ]
+    }
+  },
+  "service_network_assignments": {
+    "frontend_services": {
+      "networks": [
+        "sushi_frontend",
+        "sushi_backend"
+      ],
+      "service_types": [
+        "Web UIs (AnythingLLM, Grafana, etc.)",
+        "Reverse proxies (Caddy, Nginx)",
+        "Authentication services (Authentik)",
+        "API gateways and load balancers",
+        "Documentation sites (Docusaurus)"
+      ],
+      "example_services": [
+        "hosomaki.caddy",
+        "hosomaki.anythingllm",
+        "gunkanmaki.authentik",
+        "inari.grafana",
+        "sashimi.docusaurus"
+      ]
+    },
+    "backend_services": {
+      "networks": [
+        "sushi_backend",
+        "sushi_data"
+      ],
+      "service_types": [
+        "AI inference engines (Ollama, vLLM)",
+        "Workflow orchestrators (n8n)",
+        "Processing services (Whisper, ComfyUI)",
+        "API middleware and business logic",
+        "Monitoring collectors (Prometheus)"
+      ],
+      "example_services": [
+        "hosomaki.ollama",
+        "hosomaki.n8n",
+        "temaki.whisper",
+        "uramaki.comfyui",
+        "inari.prometheus"
+      ]
+    },
+    "data_services": {
+      "networks": [
+        "sushi_data"
+      ],
+      "service_types": [
+        "Databases (PostgreSQL, MySQL)",
+        "Vector databases (Qdrant, Weaviate)",
+        "Caches (Redis, Valkey)",
+        "Object storage (MinIO)",
+        "Search engines (Elasticsearch)"
+      ],
+      "example_services": [
+        "futomaki.postgresql",
+        "futomaki.qdrant",
+        "futomaki.redis",
+        "futomaki.minio"
+      ]
+    }
+  },
+  "communication_patterns": {
+    "frontend_to_backend": {
+      "description": "User interfaces calling AI services and APIs",
+      "examples": [
+        "AnythingLLM → Ollama for LLM inference",
+        "Grafana → Prometheus for metrics data",
+        "Web UI → n8n for workflow management"
+      ],
+      "connection_method": "HTTP/HTTPS over backend network",
+      "security_considerations": [
+        "All API calls should use proper authentication",
+        "Consider rate limiting to prevent abuse",
+        "Log API calls for audit purposes"
+      ]
+    },
+    "backend_to_data": {
+      "description": "Processing services accessing storage systems",
+      "examples": [
+        "Ollama → PostgreSQL for session storage",
+        "n8n → Redis for job queuing",
+        "Prometheus → its own storage volumes"
+      ],
+      "connection_method": "Native protocols over data network",
+      "security_considerations": [
+        "Use strong database passwords",
+        "Implement connection pooling",
+        "Monitor for unusual access patterns"
+      ]
+    },
+    "security_boundaries": {
+      "frontend_to_data": "BLOCKED - Frontend cannot directly access data layer",
+      "external_to_backend": "BLOCKED - Backend services not externally accessible",
+      "external_to_data": "BLOCKED - Data services completely isolated"
+    }
+  },
+  "security_improvements": {
+    "network_isolation": {
+      "description": "Services isolated by function and risk level",
+      "benefits": [
+        "Compromised frontend cannot directly access databases",
+        "Data breaches limited to specific network segments",
+        "Easier to monitor and control inter-service communication",
+        "Simplified compliance through clear data flow boundaries"
+      ]
+    },
+    "access_controls": {
+      "description": "Network-level restrictions on service communication",
+      "implementation": [
+        "Frontend services cannot bypass backend to reach data",
+        "Data services protected from direct external access",
+        "Backend services isolated from external attack surface"
+      ]
+    },
+    "monitoring_advantages": {
+      "description": "Network segmentation enables better security monitoring",
+      "capabilities": [
+        "Monitor cross-network communication for anomalies",
+        "Separate logging for different security zones",
+        "Easier to detect lateral movement attacks",
+        "Clear audit trails for compliance reporting"
+      ]
+    }
+  },
+  "operational_impact": {
+    "service_discovery": {
+      "description": "How services find each other across network boundaries",
+      "patterns": [
+        "Use environment variables for cross-network service URLs",
+        "Implement service registration for dynamic discovery",
+        "Maintain DNS entries for critical service endpoints"
+      ],
+      "example_configurations": [
+        "DATABASE_URL=postgresql://user:pass@postgresql.sushi_data:5432/db",
+        "OLLAMA_API_URL=http://ollama.sushi_backend:11434"
+      ]
+    },
+    "debugging_complexity": {
+      "description": "Network segmentation adds troubleshooting complexity",
+      "considerations": [
+        "Services may not be able to directly ping each other",
+        "Need to understand which networks each service uses",
+        "Cross-network communication requires proper routing"
+      ],
+      "debugging_strategies": [
+        "Use network-aware monitoring tools",
+        "Implement comprehensive health checks",
+        "Maintain network topology documentation"
+      ]
+    },
+    "deployment_coordination": {
+      "description": "Services must start in proper order across networks",
+      "requirements": [
+        "Data services start first (databases, storage)",
+        "Backend services start second (processing, APIs)",
+        "Frontend services start last (user interfaces)"
+      ],
+      "automation_approaches": [
+        "Use Docker Compose depends_on with health checks",
+        "Implement startup coordination in orchestration scripts",
+        "Monitor service readiness across all network tiers"
+      ]
+    }
+  },
+  "monitoring_strategy": {
+    "network_monitoring": {
+      "description": "Monitor health and performance of each network segment",
+      "metrics_to_track": [
+        "Inter-network traffic volumes and patterns",
+        "Network latency between tiers",
+        "Failed connection attempts across boundaries",
+        "Bandwidth utilization per network segment"
+      ]
+    },
+    "service_discovery_monitoring": {
+      "description": "Ensure services can find each other across networks",
+      "health_checks": [
+        "DNS resolution across network boundaries",
+        "Port accessibility between authorized service pairs",
+        "Authentication success rates for cross-tier calls",
+        "API response times across network hops"
+      ]
+    },
+    "security_monitoring": {
+      "description": "Detect potential security issues in network communication",
+      "alerting_criteria": [
+        "Unexpected cross-network communication attempts",
+        "Services trying to access unauthorized network segments",
+        "Unusual traffic patterns between tiers",
+        "Failed authentication attempts across networks"
+      ]
+    }
+  },
+  "compliance_features": {
+    "data_flow_control": {
+      "description": "Clear boundaries for data movement and access",
+      "advantages": [
+        "Data processing isolated from user access points",
+        "Storage systems protected from direct external access",
+        "Clear audit trail of data access patterns",
+        "Simplified compliance reporting for data handling"
+      ]
+    },
+    "network_audit_logging": {
+      "description": "Comprehensive logging of network communications",
+      "log_sources": [
+        "Docker network driver logs",
+        "Service-to-service API call logs",
+        "Authentication and authorization logs",
+        "Network access control violation logs"
+      ]
+    },
+    "incident_response": {
+      "description": "Network segmentation aids security incident response",
+      "capabilities": [
+        "Isolate compromised services by network segment",
+        "Trace attack progression through network boundaries",
+        "Implement emergency network isolation procedures",
+        "Maintain service availability during incident response"
+      ]
+    }
+  },
+  "migration_guidance": {
+    "from_open_research": {
+      "description": "Upgrading from single network to segmented architecture",
+      "steps": [
+        "Audit current service communication patterns",
+        "Assign services to appropriate network tiers",
+        "Update service configurations for new network hostnames",
+        "Test inter-service communication across network boundaries",
+        "Implement monitoring for new network architecture"
+      ],
+      "common_challenges": [
+        "Services hardcoded with simple hostnames",
+        "Applications assuming all services are directly reachable",
+        "Health checks that need cross-network access",
+        "Monitoring systems that need visibility across tiers"
+      ]
+    },
+    "to_legal_privilege": {
+      "description": "Further hardening for maximum security requirements",
+      "additional_requirements": [
+        "Add audit logging network for compliance monitoring",
+        "Implement encryption for all inter-service communication",
+        "Add authentication for all cross-network API calls",
+        "Enable comprehensive network traffic logging",
+        "Implement data retention and purge capabilities"
+      ]
+    }
+  },
+  "validation_procedures": {
+    "network_connectivity_tests": {
+      "description": "Verify services can reach authorized destinations",
+      "test_cases": [
+        "Frontend service → Backend service API",
+        "Backend service → Data service database",
+        "Monitoring service → Services in all tiers",
+        "Frontend service → Data service directly",
+        "External client → Backend service directly",
+        "External client → Data service directly"
+      ]
+    },
+    "security_boundary_validation": {
+      "description": "Confirm network isolation is effective",
+      "verification_methods": [
+        "Attempt unauthorized cross-network connections",
+        "Verify data services are not externally accessible",
+        "Test that network failures don't cascade inappropriately",
+        "Confirm monitoring can detect unauthorized access attempts"
+      ]
+    },
+    "operational_readiness_checks": {
+      "description": "Ensure the segmented network supports business operations",
+      "success_criteria": [
+        "All business workflows function correctly",
+        "Performance is acceptable across network boundaries",
+        "Monitoring provides adequate visibility",
+        "Incident response procedures work as designed"
+      ]
+    }
+  }
+}

--- a/docs/manifest/web/api/templates/network-profiles/legal-privilege.json
+++ b/docs/manifest/web/api/templates/network-profiles/legal-privilege.json
@@ -1,0 +1,498 @@
+{
+  "networks": {
+    "sushi_public": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "false",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.24.0.0/28",
+            "gateway": "172.24.0.1",
+            "ip_range": "172.24.0.0/29"
+          }
+        ]
+      },
+      "labels": [
+        "sushi.kitchen.network.profile=legal_privilege",
+        "sushi.kitchen.network.tier=public",
+        "sushi.kitchen.network.access=external",
+        "sushi.kitchen.network.purpose=controlled_entry",
+        "sushi.kitchen.compliance.audit=required",
+        "sushi.kitchen.compliance.encryption=required"
+      ]
+    },
+    "sushi_processing": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.25.0.0/24",
+            "gateway": "172.25.0.1",
+            "ip_range": "172.25.0.0/25"
+          }
+        ]
+      },
+      "internal": false,
+      "labels": [
+        "sushi.kitchen.network.profile=legal_privilege",
+        "sushi.kitchen.network.tier=processing",
+        "sushi.kitchen.network.access=internal",
+        "sushi.kitchen.network.purpose=business_logic",
+        "sushi.kitchen.compliance.audit=comprehensive",
+        "sushi.kitchen.compliance.authentication=required"
+      ]
+    },
+    "sushi_storage": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "false",
+        "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.26.0.0/24",
+            "gateway": "172.26.0.1",
+            "ip_range": "172.26.0.0/25"
+          }
+        ]
+      },
+      "internal": true,
+      "labels": [
+        "sushi.kitchen.network.profile=legal_privilege",
+        "sushi.kitchen.network.tier=storage",
+        "sushi.kitchen.network.access=none",
+        "sushi.kitchen.network.purpose=data_protection",
+        "sushi.kitchen.compliance.audit=complete",
+        "sushi.kitchen.compliance.encryption=at_rest_and_transit",
+        "sushi.kitchen.compliance.retention=managed"
+      ]
+    },
+    "sushi_audit": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true",
+        "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.27.0.0/24",
+            "gateway": "172.27.0.1",
+            "ip_range": "172.27.0.0/26"
+          }
+        ]
+      },
+      "external": false,
+      "labels": [
+        "sushi.kitchen.network.profile=legal_privilege",
+        "sushi.kitchen.network.tier=audit",
+        "sushi.kitchen.network.access=monitoring",
+        "sushi.kitchen.network.purpose=compliance_audit",
+        "sushi.kitchen.compliance.immutable=true",
+        "sushi.kitchen.compliance.retention=long_term"
+      ]
+    }
+  },
+  "service_network_assignments": {
+    "public_services": {
+      "networks": [
+        "sushi_public",
+        "sushi_audit"
+      ],
+      "allowed_services": [
+        "Reverse proxy (Caddy) with WAF and DDoS protection",
+        "Authentication gateway (Authentik) with MFA required",
+        "Static documentation (minimal, read-only content)"
+      ],
+      "security_requirements": [
+        "Mandatory HTTPS with perfect forward secrecy",
+        "Web Application Firewall (WAF) enabled",
+        "DDoS protection and rate limiting",
+        "Intrusion detection and prevention",
+        "All connections logged and monitored"
+      ],
+      "example_services": [
+        "hosomaki.caddy (with security hardening)",
+        "gunkanmaki.authentik (MFA enforced)"
+      ]
+    },
+    "processing_services": {
+      "networks": [
+        "sushi_processing",
+        "sushi_storage",
+        "sushi_audit"
+      ],
+      "allowed_services": [
+        "AI inference services with access controls",
+        "Workflow engines with audit logging",
+        "Business APIs with authentication",
+        "User interfaces requiring authentication"
+      ],
+      "security_requirements": [
+        "Mutual TLS for all inter-service communication",
+        "Service-to-service authentication tokens",
+        "Comprehensive activity logging",
+        "Data access authorization checks",
+        "Session management and timeout controls"
+      ],
+      "example_services": [
+        "hosomaki.ollama (with access controls)",
+        "hosomaki.n8n (with audit logging)",
+        "hosomaki.anythingllm (authenticated access only)",
+        "inari.grafana (admin access only)"
+      ]
+    },
+    "storage_services": {
+      "networks": [
+        "sushi_storage",
+        "sushi_audit"
+      ],
+      "allowed_services": [
+        "Databases with encryption at rest and in transit",
+        "Vector databases with access controls",
+        "Object storage with versioning and audit trails",
+        "Backup systems with encryption and integrity checking"
+      ],
+      "security_requirements": [
+        "Encryption at rest with key rotation",
+        "Encryption in transit with certificate validation",
+        "Database-level access controls and audit logs",
+        "Data integrity verification and corruption detection",
+        "Automated backup with encryption and offsite storage"
+      ],
+      "example_services": [
+        "futomaki.postgresql (encrypted, audited)",
+        "futomaki.qdrant (access-controlled, logged)",
+        "futomaki.minio (versioned, encrypted)",
+        "futomaki.redis (secured, monitored)"
+      ]
+    },
+    "audit_services": {
+      "networks": [
+        "sushi_audit",
+        "sushi_public",
+        "sushi_processing",
+        "sushi_storage"
+      ],
+      "allowed_services": [
+        "Log aggregation and analysis systems",
+        "Security information and event management (SIEM)",
+        "Compliance reporting and dashboard systems",
+        "Intrusion detection and response systems"
+      ],
+      "security_requirements": [
+        "Immutable log storage with integrity verification",
+        "Real-time security monitoring and alerting",
+        "Automated compliance reporting",
+        "Long-term log retention with secure archival",
+        "Incident response automation and escalation"
+      ],
+      "example_services": [
+        "inari.prometheus (security monitoring mode)",
+        "Log aggregation service (ELK stack or similar)",
+        "SIEM system for compliance reporting",
+        "Backup verification and integrity checking"
+      ]
+    }
+  },
+  "communication_security": {
+    "encryption_standards": {
+      "public_to_processing": {
+        "protocol": "HTTPS with TLS 1.3 minimum",
+        "authentication": "Client certificates required",
+        "cipher_suites": "AEAD ciphers only (AES-GCM, ChaCha20-Poly1305)",
+        "key_rotation": "Weekly certificate rotation",
+        "perfect_forward_secrecy": "Required"
+      },
+      "processing_to_storage": {
+        "protocol": "Mutual TLS with database-specific encryption",
+        "authentication": "Service accounts with rotating secrets",
+        "database_encryption": "AES-256 encryption at rest",
+        "key_management": "External key management service (KMS)",
+        "connection_pooling": "Encrypted connection pools only"
+      },
+      "audit_communications": {
+        "protocol": "TLS with audit-specific certificates",
+        "log_integrity": "Cryptographic log signing",
+        "tamper_detection": "Hash-based integrity verification",
+        "retention_encryption": "Long-term encryption with secure key escrow"
+      }
+    },
+    "access_controls": {
+      "service_authentication": {
+        "method": "JWT tokens with short expiration (15 minutes)",
+        "refresh_mechanism": "Secure token refresh with audit logging",
+        "service_accounts": "Dedicated accounts per service with minimal privileges",
+        "secret_rotation": "Automated daily secret rotation"
+      },
+      "user_authentication": {
+        "multi_factor": "Required for all human access",
+        "session_management": "Secure session tokens with timeout",
+        "privilege_escalation": "Explicit approval required with audit trail",
+        "emergency_access": "Break-glass procedures with comprehensive logging"
+      },
+      "data_access_authorization": {
+        "principle": "Least privilege with explicit deny by default",
+        "data_classification": "Automatic data tagging and access control",
+        "access_reviews": "Monthly automated access privilege reviews",
+        "anomaly_detection": "ML-based unusual access pattern detection"
+      }
+    }
+  },
+  "compliance_framework": {
+    "hipaa_compliance": {
+      "data_protection": [
+        "Encryption of all PHI at rest and in transit",
+        "Access controls with minimum necessary principle",
+        "Automatic PHI detection and classification",
+        "Data retention and secure deletion policies"
+      ],
+      "audit_requirements": [
+        "Comprehensive access logs for all PHI access",
+        "User authentication and authorization tracking",
+        "Data modification and deletion audit trails",
+        "Regular compliance reports and violation alerts"
+      ],
+      "technical_safeguards": [
+        "User access management with role-based controls",
+        "Automatic logoff after inactivity periods",
+        "Data backup and disaster recovery procedures",
+        "Network transmission security with encryption"
+      ]
+    },
+    "sox_compliance": {
+      "financial_controls": [
+        "Segregation of duties in data access and modification",
+        "Change management controls with approval workflows",
+        "Data integrity verification and error detection",
+        "Financial data retention and immutable audit trails"
+      ],
+      "it_controls": [
+        "Access controls with regular review and certification",
+        "System change controls with testing and approval",
+        "Data backup and recovery controls with testing",
+        "Incident response and problem management procedures"
+      ]
+    },
+    "gdpr_compliance": {
+      "privacy_rights": [
+        "Data subject access request automation",
+        "Right to deletion with secure data purging",
+        "Data portability with standard export formats",
+        "Consent management and withdrawal tracking"
+      ],
+      "data_protection": [
+        "Privacy by design in all system components",
+        "Data minimization with automatic purging",
+        "Pseudonymization and anonymization capabilities",
+        "Data breach detection and notification automation"
+      ]
+    }
+  },
+  "security_monitoring": {
+    "threat_detection": {
+      "network_monitoring": [
+        "Intrusion detection system (IDS) on all network boundaries",
+        "Deep packet inspection for malicious content",
+        "Behavioral analysis for anomalous network patterns",
+        "Automated threat response and containment"
+      ],
+      "access_monitoring": [
+        "Failed authentication attempt tracking and alerting",
+        "Privilege escalation detection and prevention",
+        "Unusual data access pattern identification",
+        "Concurrent session monitoring and control"
+      ],
+      "data_monitoring": [
+        "Data exfiltration detection and prevention",
+        "Unauthorized data modification alerting",
+        "Large data transfer monitoring and approval",
+        "Data integrity verification and corruption alerting"
+      ]
+    },
+    "compliance_monitoring": {
+      "automated_reporting": [
+        "Daily compliance status dashboards",
+        "Weekly security posture assessments",
+        "Monthly audit trail summaries",
+        "Quarterly compliance certification reports"
+      ],
+      "violation_detection": [
+        "Policy violation automatic detection and alerting",
+        "Access control bypass attempt identification",
+        "Data handling policy compliance verification",
+        "Security configuration drift detection"
+      ]
+    },
+    "incident_response": {
+      "automated_containment": [
+        "Suspicious activity automatic network isolation",
+        "Compromised account automatic suspension",
+        "Malware detection and quarantine procedures",
+        "Data breach containment and evidence preservation"
+      ],
+      "escalation_procedures": [
+        "Security incident automatic escalation workflows",
+        "Compliance violation notification procedures",
+        "Executive reporting for significant security events",
+        "External notification for regulatory violations"
+      ]
+    }
+  },
+  "data_lifecycle_management": {
+    "retention_policies": {
+      "audit_logs": {
+        "retention_period": "7 years (SOX compliance)",
+        "storage_tier": "Immutable archive with encryption",
+        "access_controls": "Read-only with audit trail",
+        "purge_procedure": "Secure deletion with certification"
+      },
+      "application_data": {
+        "retention_period": "Configurable by data classification",
+        "storage_tier": "Encrypted with regular key rotation",
+        "access_controls": "Role-based with least privilege",
+        "purge_procedure": "Secure overwrite with verification"
+      },
+      "personal_data": {
+        "retention_period": "GDPR-compliant based on purpose",
+        "storage_tier": "Pseudonymized with separation of identifiers",
+        "access_controls": "Purpose limitation with consent tracking",
+        "purge_procedure": "Right to deletion with proof of erasure"
+      },
+      "temporary_data": {
+        "retention_period": "24-48 hours maximum",
+        "storage_tier": "Encrypted temporary storage",
+        "access_controls": "Process-specific with time limits",
+        "purge_procedure": "Automatic secure deletion"
+      }
+    },
+    "lifecycle_automation": {
+      "daily_tasks": [
+        "Temporary data cleanup and verification",
+        "Access log integrity verification",
+        "Backup completion and validation checks",
+        "Security alert review and triage"
+      ],
+      "weekly_tasks": [
+        "Data retention policy compliance verification",
+        "Access privilege review and cleanup",
+        "Security configuration assessment",
+        "Compliance dashboard updates"
+      ],
+      "monthly_tasks": [
+        "Full data inventory and classification review",
+        "Archive data migration and verification",
+        "Security control effectiveness assessment",
+        "Compliance audit preparation and reporting"
+      ],
+      "quarterly_tasks": [
+        "Complete data purging and certification",
+        "Security architecture review and updates",
+        "Compliance certification and external reporting",
+        "Disaster recovery testing and documentation"
+      ]
+    }
+  },
+  "operational_procedures": {
+    "secure_deployment": {
+      "change_approval": [
+        "All changes require multi-person approval",
+        "Security impact assessment mandatory",
+        "Rollback procedures tested and documented",
+        "Change audit trail with comprehensive logging"
+      ],
+      "testing_requirements": [
+        "Security testing in isolated environment",
+        "Compliance verification before production",
+        "Performance impact assessment",
+        "Integration testing with audit systems"
+      ],
+      "production_deployment": [
+        "Maintenance windows with advance notification",
+        "Zero-downtime deployment for critical systems",
+        "Immediate post-deployment verification",
+        "Continuous monitoring during deployment"
+      ]
+    },
+    "emergency_response": {
+      "security_incidents": [
+        "Immediate isolation of affected systems",
+        "Evidence preservation and forensic imaging",
+        "Stakeholder notification within required timeframes",
+        "Recovery procedures with security verification"
+      ],
+      "compliance_violations": [
+        "Immediate violation containment and documentation",
+        "Root cause analysis and corrective action plans",
+        "Regulatory notification if required",
+        "Process improvement and prevention measures"
+      ],
+      "system_failures": [
+        "Failover to secure backup systems",
+        "Data integrity verification during recovery",
+        "Security control restoration and verification",
+        "Comprehensive incident documentation and lessons learned"
+      ]
+    }
+  },
+  "compliance_validation": {
+    "daily_checks": {
+      "security_status": [
+        "All services running with current security patches",
+        "Network isolation functioning correctly",
+        "Authentication systems operational and secure",
+        "Audit logging capturing all required events"
+      ],
+      "data_protection": [
+        "Encryption functioning for all data at rest and in transit",
+        "Access controls enforced and logged",
+        "Data backup completion and integrity verification",
+        "Retention policies applied correctly"
+      ]
+    },
+    "weekly_assessments": {
+      "configuration_compliance": [
+        "Security configurations match approved baselines",
+        "Network segmentation rules enforced correctly",
+        "Service accounts and privileges reviewed",
+        "Monitoring and alerting systems functional"
+      ],
+      "audit_readiness": [
+        "Audit logs complete and tamper-evident",
+        "Compliance reports generated and reviewed",
+        "Documentation current and accessible",
+        "Emergency procedures tested and verified"
+      ]
+    },
+    "monthly_certification": {
+      "comprehensive_review": [
+        "Full security control effectiveness assessment",
+        "Compliance gap analysis and remediation planning",
+        "Risk assessment updates and mitigation verification",
+        "Executive reporting and certification sign-off"
+      ],
+      "external_validation": [
+        "Third-party security assessment coordination",
+        "Regulatory compliance verification",
+        "Audit firm coordination and evidence provision",
+        "Certification maintenance and renewal planning"
+      ]
+    }
+  }
+}

--- a/docs/manifest/web/api/templates/network-profiles/open-research.json
+++ b/docs/manifest/web/api/templates/network-profiles/open-research.json
@@ -1,0 +1,112 @@
+{
+  "networks": {
+    "sushi_net": {
+      "driver": "bridge",
+      "driver_opts": {
+        "com.docker.network.bridge.enable_icc": "true",
+        "com.docker.network.bridge.enable_ip_masquerade": "true"
+      },
+      "ipam": {
+        "driver": "default",
+        "config": [
+          {
+            "subnet": "172.20.0.0/16",
+            "gateway": "172.20.0.1",
+            "ip_range": "172.20.1.0/24"
+          }
+        ]
+      },
+      "labels": [
+        "sushi.kitchen.network.profile=open_research",
+        "sushi.kitchen.network.isolation=minimal",
+        "sushi.kitchen.network.purpose=development"
+      ]
+    }
+  },
+  "service_network_template": {
+    "networks": [
+      "sushi_net"
+    ]
+  },
+  "network_aliases_template": {
+    "networks": {
+      "sushi_net": {
+        "aliases": [
+          "${SERVICE_STYLE}.${SERVICE_NAME}",
+          "${SERVICE_NAME}"
+        ]
+      }
+    }
+  },
+  "dns_configuration": {
+    "enable_service_discovery": true,
+    "dns_servers": [
+      "172.20.0.1"
+    ],
+    "dns_search": [
+      "sushi_net"
+    ]
+  },
+  "logging_configuration": {
+    "driver": "json-file",
+    "options": {
+      "max-size": "50m",
+      "max-file": "5",
+      "labels": "sushi.service,sushi.style,sushi.network"
+    }
+  },
+  "port_exposure": {
+    "expose_all_ports": true,
+    "port_range_start": 3000,
+    "port_range_end": 9999,
+    "document_port_assignments": true
+  },
+  "development_optimizations": {
+    "enable_bind_mounts": true,
+    "allow_privileged_containers": false,
+    "enable_debug_tools": true,
+    "health_check_interval": "15s",
+    "health_check_start_period": "60s"
+  },
+  "resource_strategy": {
+    "memory_overcommit_factor": 1.5,
+    "cpu_overcommit_factor": 2.0,
+    "storage_monitoring": "advisory"
+  },
+  "validation_tests": null,
+  "troubleshooting_commands": {
+    "network_inspection": "docker network ls | grep sushi",
+    "container_networks": "docker-compose ps --format table",
+    "network_details": "docker network inspect sushi-kitchen_sushi_net",
+    "connectivity_test": "docker-compose exec {service1} ping {service2}",
+    "dns_resolution": "docker-compose exec {service} nslookup {target-service}",
+    "port_listening": "docker-compose exec {service} netstat -tlnp"
+  },
+  "migration_guidance": {
+    "to_business_confidential": {
+      "description": "Add network segmentation for moderate security",
+      "changes_required": [
+        "Split services across frontend/backend/data networks",
+        "Add network access controls between tiers",
+        "Update service configurations for new hostnames"
+      ]
+    },
+    "to_legal_privilege": {
+      "description": "Maximum isolation for sensitive data",
+      "changes_required": [
+        "Implement comprehensive network segmentation",
+        "Add audit logging for all network traffic",
+        "Enable encryption for inter-service communication",
+        "Implement access controls and authentication"
+      ]
+    },
+    "backwards_compatibility": {
+      "description": "Ensure services work across different network profiles",
+      "considerations": [
+        "Use environment variables for service URLs",
+        "Don't hardcode hostnames in application configuration",
+        "Design services to work with different network topologies"
+      ]
+    }
+  }
+}

--- a/docs/manifest/web/manifest-index.json
+++ b/docs/manifest/web/manifest-index.json
@@ -1,0 +1,71 @@
+{
+  "generated_at": "2025-09-18T17:24:01.541746+00:00",
+  "manifest_metadata": {
+    "name": "Sushi Kitchen Manifest System",
+    "version": "0.1.0",
+    "schema_version": "0.1.0",
+    "last_updated": "2025-09-18T22:45:00Z",
+    "description": "Comprehensive Docker Compose framework for AI infrastructure deployment with intelligent dependency resolution and resource management",
+    "repository": "https://github.com/yourusername/sushi-kitchen",
+    "documentation_url": "https://sushi-kitchen.dev/docs/manifest",
+    "license": "MIT"
+  },
+  "source_root": "..",
+  "files": [
+    {
+      "source": "core/badges.yml",
+      "output": "api/core/badges.json",
+      "sha256": "b05a189ed9fd77adea3f293f03c9d2dd733dc08a6536803b6671de05a39b3573"
+    },
+    {
+      "source": "core/bento-box.yml",
+      "output": "api/core/bento-box.json",
+      "sha256": "fa465511a073bb2c0c04f90c7307d32a5297083d09e4697f2148902b34cc614e"
+    },
+    {
+      "source": "core/combos.yml",
+      "output": "api/core/combos.json",
+      "sha256": "3cc016d4007206bc6368617d340b7b1b83e1a08b326c38936a52e3a99316f232"
+    },
+    {
+      "source": "core/contracts.yml",
+      "output": "api/core/contracts.json",
+      "sha256": "3950ea4f58f93f5444ebce70c65a072a46cf3c3775b6ebce015cece97360cd58"
+    },
+    {
+      "source": "core/platters.yml",
+      "output": "api/core/platters.json",
+      "sha256": "351238342f52fdfd07fbf4e2b9fd68b6b250175a904787aaf993c0c8ed111f09"
+    },
+    {
+      "source": "examples/basic-rag-setup/docker-compose.yml",
+      "output": "api/examples/basic-rag-setup/docker-compose.json",
+      "sha256": "54357451fc2f0f60f91dc0ad7cf73c0d0e462521c1903e450797b06e93dfef1b"
+    },
+    {
+      "source": "templates/environment-configs/development.yml",
+      "output": "api/templates/environment-configs/development.json",
+      "sha256": "de3fbacd92ffc01e5bbd0b5b6ae1c25c1b2271ca4de28b813405d52693b53415"
+    },
+    {
+      "source": "templates/environment-configs/production.yml",
+      "output": "api/templates/environment-configs/production.json",
+      "sha256": "91ad729ea36fb66d16f180d031874714f78f97a3c7ecf3453ebbf2d54e380dbf"
+    },
+    {
+      "source": "templates/network-profiles/business-confidential.yml",
+      "output": "api/templates/network-profiles/business-confidential.json",
+      "sha256": "974d737a31218ad06aaed9da4ab8778237634d9f9da000bb71c323e1887185a0"
+    },
+    {
+      "source": "templates/network-profiles/legal-privilege.yml",
+      "output": "api/templates/network-profiles/legal-privilege.json",
+      "sha256": "64125602376174a11812277eb9f83ce64daccfef8de5f2bf7334440b383c7c94"
+    },
+    {
+      "source": "templates/network-profiles/open-research.yml",
+      "output": "api/templates/network-profiles/open-research.json",
+      "sha256": "ff8fc90b749d9ce3e3600cbea2838bb91b3643126084800833b95d66209ce773"
+    }
+  ]
+}

--- a/scripts/export-manifest-json.py
+++ b/scripts/export-manifest-json.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Sushi Kitchen — Manifest JSON exporter
+
+Converts YAML manifests under ``docs/manifest`` into JSON files for the
+website/front-end layer.  Outputs mirror the source folder structure so that
+static site generators or SPAs can fetch machine-ready snapshots without
+parsing YAML at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import yaml
+
+MANIFEST_METADATA_FILE = "_metadata.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert manifest YAML to JSON")
+    parser.add_argument(
+        "--manifest-root",
+        type=Path,
+        default=Path("docs/manifest"),
+        help="Root directory that contains the manifest source files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("docs/manifest/web/api"),
+        help="Destination directory for the generated JSON files.",
+    )
+    parser.add_argument(
+        "--include-archives",
+        action="store_true",
+        help="Also convert files inside the archives/ directory.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output with indentation (default is compact).",
+    )
+    return parser.parse_args()
+
+
+def discover_yaml_files(
+    manifest_root: Path, include_archives: bool = False
+) -> Iterable[Path]:
+    """Yield all YAML files under the manifest tree."""
+    for extension in ("*.yml", "*.yaml"):
+        for path in manifest_root.rglob(extension):
+            if not include_archives and "archives" in path.relative_to(manifest_root).parts:
+                continue
+            yield path
+
+
+def read_manifest_metadata(manifest_root: Path) -> Dict:
+    metadata_path = manifest_root / MANIFEST_METADATA_FILE
+    if not metadata_path.exists():
+        return {}
+    with metadata_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def convert_yaml_file(
+    source_path: Path, manifest_root: Path, output_root: Path, pretty: bool
+) -> Optional[Tuple[Path, Dict]]:
+    """Convert a single YAML file to JSON and return output path + index record."""
+    relative_path = source_path.relative_to(manifest_root)
+    target_path = (output_root / relative_path).with_suffix(".json")
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with source_path.open("r", encoding="utf-8") as src:
+            content = yaml.safe_load(src) or {}
+    except yaml.YAMLError as err:
+        print(f"Skipping {relative_path} (YAML parse error: {err})")
+        return None
+
+    with target_path.open("w", encoding="utf-8") as dest:
+        if pretty:
+            json.dump(content, dest, indent=2, ensure_ascii=False)
+            dest.write("\n")
+        else:
+            json.dump(content, dest, separators=(",", ":"), ensure_ascii=False)
+
+    with source_path.open("rb") as src_bytes:
+        sha256 = hashlib.sha256(src_bytes.read()).hexdigest()
+
+    record = {
+        "source": str(relative_path).replace("\\", "/"),
+        "output": str(target_path.relative_to(output_root.parent)).replace("\\", "/"),
+        "sha256": sha256,
+    }
+    return target_path, record
+
+
+def write_index(
+    index_path: Path,
+    records: List[Dict],
+    manifest_metadata: Dict,
+    manifest_root: Path,
+) -> None:
+    index_payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "manifest_metadata": manifest_metadata.get("manifest_system", {}),
+        "source_root": os.path.relpath(manifest_root, start=index_path.parent),
+        "files": records,
+    }
+    with index_path.open("w", encoding="utf-8") as fh:
+        json.dump(index_payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main() -> None:
+    args = parse_args()
+    manifest_root = args.manifest_root.resolve()
+    output_root = args.output_dir.resolve()
+
+    if not manifest_root.exists():
+        raise SystemExit(f"Manifest root not found: {manifest_root}")
+
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    records: List[Dict] = []
+    skipped = 0
+    for yaml_file in sorted(discover_yaml_files(manifest_root, args.include_archives)):
+        result = convert_yaml_file(yaml_file, manifest_root, output_root, args.pretty)
+        if result is None:
+            skipped += 1
+            continue
+        _, record = result
+        records.append(record)
+
+    manifest_metadata = read_manifest_metadata(manifest_root)
+    index_path = output_root.parent / "manifest-index.json"
+    write_index(index_path, records, manifest_metadata, manifest_root)
+
+    print(f"Converted {len(records)} YAML files into JSON under {output_root}")
+    if skipped:
+        print(f"Skipped {skipped} file(s) due to YAML parse errors or unsupported syntax")
+    print(f"Index written to {index_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `scripts/export-manifest-json.py` helper that mirrors manifest YAML into JSON for website use
- document the new `docs/manifest/web/` export surface and generate the current JSON snapshot with an index file
- update the manifest README to point consumers at the export workflow

## Testing
- `python scripts/export-manifest-json.py --manifest-root docs/manifest --output-dir docs/manifest/web/api --pretty`


------
https://chatgpt.com/codex/tasks/task_e_68c4f0b766e0832fbfdbf7854ec9629d