### PR TITLE
Adjust roll integration snippets to use Compose service keys

### DIFF
--- a/docs/manifest/narratives/rolls/generate_roll.py
+++ b/docs/manifest/narratives/rolls/generate_roll.py
@@ -1,0 +1,121 @@
+"""Utilities for generating narrative roll documentation."""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class _ConfigurationSnippet:
+    """Metadata describing a Compose override example for a roll."""
+
+    title: str
+    description: str
+    service_id: str
+    example_template: str
+
+    def render(self) -> Dict[str, str]:
+        """Render the snippet to a serialisable dictionary."""
+
+        example = _render_example(self.example_template, self.service_id)
+        return {
+            "title": self.title,
+            "description": self.description,
+            "example": example,
+        }
+
+
+def _service_key(service_id: str) -> str:
+    """Return the Docker Compose service key for ``service_id``."""
+
+    return service_id.split(".")[-1]
+
+
+def _render_example(template: str, service_id: str) -> str:
+    """Format *template* with the Compose service key for *service_id*."""
+
+    example = template.format(service_key=_service_key(service_id))
+    return textwrap.dedent(example).rstrip()
+
+
+class RollTemplateGenerator:
+    """Generate metadata blocks for roll narrative documents."""
+
+    def __init__(self, service_id: str) -> None:
+        self.service_id = service_id
+
+    def build(self) -> Dict[str, Any]:
+        """Return the metadata dictionary for the configured roll."""
+
+        return {
+            "integration_notes": self._integration_metadata(),
+        }
+
+    # ------------------------------------------------------------------
+    # Metadata helpers
+    # ------------------------------------------------------------------
+    def _integration_metadata(self) -> Dict[str, Any]:
+        """Return integration metadata for the configured roll."""
+
+        snippets = _CONFIGURATION_SNIPPETS.get(self.service_id, [])
+        automation = _AUTOMATION_PATTERNS.get(self.service_id, [])
+
+        rendered_snippets: List[Dict[str, str]] = [snippet.render() for snippet in snippets]
+        return {
+            "configuration_snippets": rendered_snippets,
+            "automation_patterns": automation,
+        }
+
+
+_CONFIGURATION_SNIPPETS: Dict[str, List[_ConfigurationSnippet]] = {
+    "hosomaki.n8n": [
+        _ConfigurationSnippet(
+            title="Connect n8n to Supabase for workflow state",
+            description="Example environment overrides to target the managed Postgres shipped with Supabase",
+            service_id="hosomaki.n8n",
+            example_template="""\
+            services:
+              {service_key}:
+                environment:
+                  DB_POSTGRESDB_HOST: "supabase-db"
+                  DB_POSTGRESDB_DATABASE: "${{N8N_DB_NAME:-n8n}}"
+                  DB_POSTGRESDB_USER: "${{SUPABASE_SERVICE_ROLE_USER}}"
+                  DB_POSTGRESDB_PASSWORD: "${{SUPABASE_SERVICE_ROLE_PASSWORD}}"
+            """,
+        ),
+    ],
+    "hosomaki.ollama": [
+        _ConfigurationSnippet(
+            title="Expose Ollama through LiteLLM",
+            description="Route multi-model traffic via LiteLLM while keeping Ollama local",
+            service_id="hosomaki.litellm",
+            example_template="""\
+            services:
+              {service_key}:
+                environment:
+                  LITELLM_ROUTES: |
+                    {{
+                      "ollama-chat": {{
+                        "host": "http://ollama:11434",
+                        "model_list": ["llama3", "mistral"],
+                        "api_key": "${{LITELLM_PROXY_KEY}}"
+                      }}
+                    }}
+            """,
+        ),
+    ],
+}
+
+
+_AUTOMATION_PATTERNS: Dict[str, List[str]] = {
+    "hosomaki.n8n": [
+        "Use webhook triggers to hand off form submissions to `hosomaki.ollama` for summarization and routing",
+        "Schedule nightly RAG ingestion workflows that enrich `futomaki.qdrant` with fresh embeddings",
+    ],
+    "hosomaki.ollama": [
+        "Schedule nightly `ollama pull` updates via `hosomaki.n8n` to keep local models fresh",
+        "Use `futomaki.qdrant` to store embeddings produced by Ollama for downstream semantic search",
+    ],
+}

--- a/docs/manifest/narratives/rolls/hosomaki.n8n.md
+++ b/docs/manifest/narratives/rolls/hosomaki.n8n.md
@@ -181,7 +181,7 @@ integration_notes:
       description: "Example environment overrides to target the managed Postgres shipped with Supabase"
       example: |-
         services:
-          hosomaki.n8n:
+          n8n:
             environment:
               DB_POSTGRESDB_HOST: "supabase-db"
               DB_POSTGRESDB_DATABASE: "${N8N_DB_NAME:-n8n}"

--- a/docs/manifest/narratives/rolls/hosomaki.ollama.md
+++ b/docs/manifest/narratives/rolls/hosomaki.ollama.md
@@ -167,7 +167,7 @@ integration_notes:
       description: "Route multi-model traffic via LiteLLM while keeping Ollama local"
       example: |-
         services:
-          hosomaki.litellm:
+          litellm:
             environment:
               LITELLM_ROUTES: |
                 {

--- a/tests/test_roll_template_generator.py
+++ b/tests/test_roll_template_generator.py
@@ -1,0 +1,37 @@
+"""Tests for the roll narrative template generator."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from docs.manifest.narratives.rolls.generate_roll import RollTemplateGenerator
+
+
+@pytest.mark.parametrize(
+    ("roll_id", "expected_service_key", "unexpected_prefix"),
+    [
+        ("hosomaki.n8n", "n8n", "hosomaki.n8n:"),
+        ("hosomaki.ollama", "litellm", "hosomaki.litellm:"),
+    ],
+)
+def test_integration_snippet_uses_compose_service_key(
+    roll_id: str, expected_service_key: str, unexpected_prefix: str
+) -> None:
+    """Ensure configuration snippets render Docker Compose keys correctly."""
+
+    generator = RollTemplateGenerator(roll_id)
+    integration_notes = generator._integration_metadata()
+
+    snippets = integration_notes["configuration_snippets"]
+    assert snippets, "Expected at least one configuration snippet"
+
+    example = snippets[0]["example"]
+    assert f"  {expected_service_key}:" in example
+    assert unexpected_prefix not in example


### PR DESCRIPTION
## Summary
- add a roll narrative generator helper that renders Compose examples with service keys derived from the manifest ID suffix
- refresh the hosomaki n8n and ollama integration snippets so their Compose overrides use the shortened service names
- add regression coverage to ensure future roll narrative examples continue to emit Compose keys without the manifest prefix

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cefccd4e48832fb9d19603d477c76d